### PR TITLE
add expense selection UI

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/Buttons.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/Buttons.kt
@@ -5,4 +5,5 @@ object Buttons {
     const val VIEW_EXPENSES = "${Icons.LIST} Расходы"
     const val CATEGORIES = "${Icons.CATEGORY} Категории"
     const val STATISTICS = "${Icons.STATS} Статистика"
+    const val CANCEL = "${Icons.CANCEL} Отмена"
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/Icons.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/Icons.kt
@@ -9,4 +9,5 @@ object Icons {
     const val LIST = "📋"
     const val STATS = "📊"
     const val CHECKMARK = "✓"
+    const val CANCEL = "❌"
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/KeyboardApplier.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/KeyboardApplier.kt
@@ -14,6 +14,8 @@ class KeyboardApplier {
             when (action) {
                 is Action.ShowMainMenu ->
                     sendMessage.replyMarkup = Keyboards.mainMenu()
+                is Action.ShowCategorySelection ->
+                    sendMessage.replyMarkup = Keyboards.categorySelection(action.categories)
             }
         }
     }

--- a/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/Keyboards.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/Keyboards.kt
@@ -1,6 +1,10 @@
 package me.kmozze.expensetracker.adapter.ui
 
+import me.kmozze.expensetracker.model.entity.Category
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardMarkup
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton
+import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardRow
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardButton
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.KeyboardRow
 
@@ -18,5 +22,36 @@ object Keyboards {
             resizeKeyboard = true
             isPersistent = true
         }
+    }
+
+    fun categorySelection(categories: List<Category>): InlineKeyboardMarkup {
+        val buttons =
+            categories.map { category ->
+                InlineKeyboardButton
+                    .builder()
+                    .text(category.name)
+                    .callbackData("select_category:${category.id}")
+                    .build()
+            }
+        val rows: List<InlineKeyboardRow> =
+            buttons
+                .chunked(2)
+                .map { InlineKeyboardRow(it) } +
+                listOf(
+                    InlineKeyboardRow(
+                        listOf(
+                            InlineKeyboardButton
+                                .builder()
+                                .text(Buttons.CANCEL)
+                                .callbackData("cancel")
+                                .build(),
+                        ),
+                    ),
+                )
+
+        return InlineKeyboardMarkup
+            .builder()
+            .keyboard(rows)
+            .build()
     }
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/MessageFormatter.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/MessageFormatter.kt
@@ -19,6 +19,24 @@ class MessageFormatter {
             is Message.UnknownCommand ->
                 "Я не понял команду 😕\nЧто бы вернуться в главное меню напиши /start"
 
+            is Message.AddExpenseInstructions ->
+                "Введите сумму и описание одним сообщением.\nНапример: `500 такси` или  `такси 500`."
+
+            is Message.SelectCategory ->
+                "💰 *${message.amount} ₽*\n📝 ${message.description}\n\nКуда запишем?"
+
+            is Message.ExpenseSaved ->
+                "✅ Сохранено!\n" +
+                    "💰 Сумма: ${message.amount} ₽\n" +
+                    "📂 Категория: ${message.categoryName}\n" +
+                    "📝 Описание: ${message.description}"
+
+            is Message.ExpenseCanceled ->
+                "Добавление расхода отменено."
+
+            is Message.FeatureInProgress ->
+                "Этот раздел пока в работе."
+
             is Message.Error -> "❌ ${formatError(message.errorCode)}"
         }
 
@@ -26,6 +44,8 @@ class MessageFormatter {
         when (errorCode) {
             BusinessErrorCode.EXPENSE_INVALID_FORMAT -> "Неверный формат. Используйте: 'Еда 500' или '500 Еда'"
             BusinessErrorCode.INVALID_AMOUNT -> "Сумма должна быть больше нуля"
+            BusinessErrorCode.CATEGORY_NOT_FOUND -> "Категория не найдена"
+            BusinessErrorCode.INVALID_CATEGORY_SELECTION -> "Не получилось выбрать категорию"
             SystemErrorCode.DATABASE_ERROR -> "Ошибка базы данных. Попробуйте позже."
             SystemErrorCode.INTERNAL_ERROR -> "Непредвиденная системная ошибка."
             else -> "Произошла неизвестная ошибка."

--- a/src/main/kotlin/me/kmozze/expensetracker/exception/ErrorCode.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/exception/ErrorCode.kt
@@ -7,6 +7,8 @@ interface ErrorCode {
 enum class BusinessErrorCode : ErrorCode {
     EXPENSE_INVALID_FORMAT,
     INVALID_AMOUNT,
+    CATEGORY_NOT_FOUND,
+    INVALID_CATEGORY_SELECTION,
     ;
 
     override val code: String get() = name

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/Action.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/Action.kt
@@ -1,5 +1,11 @@
 package me.kmozze.expensetracker.model.domain
 
+import me.kmozze.expensetracker.model.entity.Category
+
 sealed class Action {
     object ShowMainMenu : Action()
+
+    data class ShowCategorySelection(
+        val categories: List<Category>,
+    ) : Action()
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/Message.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/Message.kt
@@ -1,6 +1,7 @@
 package me.kmozze.expensetracker.model.domain
 
 import me.kmozze.expensetracker.exception.ErrorCode
+import java.math.BigDecimal
 
 sealed class Message {
     data object WelcomeFirstTime : Message()
@@ -8,6 +9,23 @@ sealed class Message {
     data object WelcomeBack : Message()
 
     data object UnknownCommand : Message()
+
+    data object AddExpenseInstructions : Message()
+
+    data class SelectCategory(
+        val amount: BigDecimal,
+        val description: String?,
+    ) : Message()
+
+    data class ExpenseSaved(
+        val amount: BigDecimal,
+        val categoryName: String,
+        val description: String,
+    ) : Message()
+
+    data object ExpenseCanceled : Message()
+
+    data object FeatureInProgress : Message()
 
     data class Error(
         val errorCode: ErrorCode,


### PR DESCRIPTION
## Что сделано
- Добавлены domain-сообщения и action для выбора категории при добавлении расхода.
- Собрана inline-клавиатура категорий с кнопкой отмены.
- Подключено применение category-selection keyboard в UI-слое.

## Что не сделано сознательно
- Сам flow сохранения расхода вынесен в следующий stacked PR.

## Как тестировать
- ./gradlew ktlintCheck test