### PR TITLE
add expense creation flow

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/handler/DialogueRouter.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/DialogueRouter.kt
@@ -28,9 +28,9 @@ class DialogueRouter(
 
             val currentState = userSessionService.getState(input.userId)
 
-            val handler = handlersByState[currentState::class] ?: unknownCommandHandler
+            val handler = handlersByState[currentState::class]
 
-            val result = handler.handle(input)
+            val result = handler?.handle(input, currentState) ?: unknownCommandHandler.handle(input)
 
             if (result.nextState != null) {
                 userSessionService.setState(input.userId, result.nextState)

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
@@ -1,0 +1,110 @@
+package me.kmozze.expensetracker.handler.statehandler
+
+import me.kmozze.expensetracker.exception.BusinessErrorCode
+import me.kmozze.expensetracker.model.domain.Action
+import me.kmozze.expensetracker.model.domain.HandlerResponse
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Message
+import me.kmozze.expensetracker.model.domain.UserInput
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import org.springframework.stereotype.Component
+import java.util.UUID
+import kotlin.reflect.KClass
+
+@Component
+class AwaitingCategorySelectionHandler(
+    private val categoryService: CategoryService,
+    private val expenseService: ExpenseService,
+) : StateHandler {
+    override val supportedStateClass: KClass<out UserState> = UserState.AwaitingCategorySelection::class
+
+    override fun handle(
+        input: UserInput,
+        currentState: UserState,
+    ): HandlerResult {
+        require(currentState is UserState.AwaitingCategorySelection) {
+            "AwaitingCategorySelectionHandler requires AwaitingCategorySelection state"
+        }
+
+        val callbackData = input.callbackData
+
+        if (callbackData == CANCEL_CALLBACK) {
+            return HandlerResult(
+                response =
+                    HandlerResponse(
+                        message = Message.ExpenseCanceled,
+                        actions = listOf(Action.ShowMainMenu),
+                    ),
+                nextState = UserState.Idle,
+            )
+        }
+
+        if (callbackData == null || !callbackData.startsWith(SELECT_CATEGORY_PREFIX)) {
+            val categories = categoryService.getCategories(input.userId)
+            return HandlerResult(
+                response =
+                    HandlerResponse(
+                        message =
+                            Message.SelectCategory(
+                                amount = currentState.parsedExpense.amount,
+                                description = currentState.parsedExpense.description,
+                            ),
+                        actions = listOf(Action.ShowCategorySelection(categories)),
+                    ),
+                nextState = currentState,
+            )
+        }
+
+        val categoryId =
+            callbackData
+                .removePrefix(SELECT_CATEGORY_PREFIX)
+                .let { runCatching { UUID.fromString(it) }.getOrNull() }
+                ?: return invalidCategorySelection(input.userId, currentState)
+
+        val category = categoryService.getCategoryForUser(categoryId, input.userId)
+
+        val expense =
+            expenseService.saveExpense(
+                userId = input.userId,
+                categoryId = category.id,
+                parsedExpense = currentState.parsedExpense,
+            )
+
+        return HandlerResult(
+            response =
+                HandlerResponse(
+                    message =
+                        Message.ExpenseSaved(
+                            amount = expense.amount,
+                            categoryName = category.name,
+                            description = expense.description.orEmpty(),
+                        ),
+                    actions = listOf(Action.ShowMainMenu),
+                ),
+            nextState = UserState.Idle,
+        )
+    }
+
+    private fun invalidCategorySelection(
+        userId: Long,
+        currentState: UserState.AwaitingCategorySelection,
+    ): HandlerResult {
+        val categories = categoryService.getCategories(userId)
+
+        return HandlerResult(
+            response =
+                HandlerResponse(
+                    message = Message.Error(BusinessErrorCode.INVALID_CATEGORY_SELECTION),
+                    actions = listOf(Action.ShowCategorySelection(categories)),
+                ),
+            nextState = currentState,
+        )
+    }
+
+    private companion object {
+        const val SELECT_CATEGORY_PREFIX = "select_category:"
+        const val CANCEL_CALLBACK = "cancel"
+    }
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseInputHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseInputHandler.kt
@@ -1,0 +1,90 @@
+package me.kmozze.expensetracker.handler.statehandler
+
+import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.exception.BusinessException
+import me.kmozze.expensetracker.model.domain.Action
+import me.kmozze.expensetracker.model.domain.HandlerResponse
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Message
+import me.kmozze.expensetracker.model.domain.UserInput
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import org.springframework.stereotype.Component
+import kotlin.reflect.KClass
+
+@Component
+class AwaitingExpenseInputHandler(
+    private val expenseService: ExpenseService,
+    private val categoryService: CategoryService,
+) : StateHandler {
+    override val supportedStateClass: KClass<out UserState> = UserState.AwaitingExpenseInput::class
+
+    override fun handle(input: UserInput): HandlerResult {
+        if (input.text == Buttons.ADD_EXPENSE) {
+            return HandlerResult(
+                response =
+                    HandlerResponse(
+                        message = Message.AddExpenseInstructions,
+                        actions = listOf(Action.ShowMainMenu),
+                    ),
+                nextState = UserState.AwaitingExpenseInput,
+            )
+        }
+
+        if (input.text in setOf(Buttons.VIEW_EXPENSES, Buttons.CATEGORIES, Buttons.STATISTICS)) {
+            return HandlerResult(
+                response =
+                    HandlerResponse(
+                        message = Message.FeatureInProgress,
+                        actions = listOf(Action.ShowMainMenu),
+                    ),
+                nextState = UserState.Idle,
+            )
+        }
+
+        val text =
+            input.text
+                ?: return HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = Message.AddExpenseInstructions,
+                            actions = listOf(Action.ShowMainMenu),
+                        ),
+                    nextState = UserState.AwaitingExpenseInput,
+                )
+
+        val parsedExpense =
+            try {
+                expenseService.parseExpense(text)
+            } catch (e: BusinessException) {
+                return HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = Message.Error(e.errorCode),
+                            actions = listOf(Action.ShowMainMenu),
+                        ),
+                    nextState = UserState.AwaitingExpenseInput,
+                )
+            }
+
+        var categories = categoryService.getCategories(input.userId)
+        if (categories.isEmpty()) {
+            categoryService.initDefaultCategories(input.userId)
+            categories = categoryService.getCategories(input.userId)
+        }
+
+        return HandlerResult(
+            response =
+                HandlerResponse(
+                    message =
+                        Message.SelectCategory(
+                            amount = parsedExpense.amount,
+                            description = parsedExpense.description,
+                        ),
+                    actions = listOf(Action.ShowCategorySelection(categories)),
+                ),
+            nextState = UserState.AwaitingCategorySelection(parsedExpense),
+        )
+    }
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/IdleStateHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/IdleStateHandler.kt
@@ -1,0 +1,52 @@
+package me.kmozze.expensetracker.handler.statehandler
+
+import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.model.domain.Action
+import me.kmozze.expensetracker.model.domain.HandlerResponse
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Message
+import me.kmozze.expensetracker.model.domain.UserInput
+import me.kmozze.expensetracker.model.domain.UserState
+import org.springframework.stereotype.Component
+import kotlin.reflect.KClass
+
+@Component
+class IdleStateHandler : StateHandler {
+    override val supportedStateClass: KClass<out UserState> = UserState.Idle::class
+
+    override fun handle(input: UserInput): HandlerResult =
+        when (input.text) {
+            Buttons.ADD_EXPENSE ->
+                HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = Message.AddExpenseInstructions,
+                            actions = listOf(Action.ShowMainMenu),
+                        ),
+                    nextState = UserState.AwaitingExpenseInput,
+                )
+
+            Buttons.VIEW_EXPENSES,
+            Buttons.CATEGORIES,
+            Buttons.STATISTICS,
+            ->
+                HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = Message.FeatureInProgress,
+                            actions = listOf(Action.ShowMainMenu),
+                        ),
+                    nextState = UserState.Idle,
+                )
+
+            else ->
+                HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = Message.UnknownCommand,
+                            actions = listOf(Action.ShowMainMenu),
+                        ),
+                    nextState = UserState.Idle,
+                )
+        }
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/StateHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/StateHandler.kt
@@ -1,9 +1,19 @@
 package me.kmozze.expensetracker.handler.statehandler
 
 import me.kmozze.expensetracker.handler.UserInputHandler
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.UserInput
 import me.kmozze.expensetracker.model.domain.UserState
 import kotlin.reflect.KClass
 
 interface StateHandler : UserInputHandler {
     val supportedStateClass: KClass<out UserState>
+
+    override fun handle(input: UserInput): HandlerResult =
+        throw IllegalStateException("${this::class.simpleName} requires current user state")
+
+    fun handle(
+        input: UserInput,
+        currentState: UserState,
+    ): HandlerResult = handle(input)
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/ParsedExpense.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/ParsedExpense.kt
@@ -3,7 +3,6 @@ package me.kmozze.expensetracker.model.domain
 import java.math.BigDecimal
 
 data class ParsedExpense(
-    val category: String,
     val amount: BigDecimal,
-    val description: String? = null,
+    val description: String,
 )

--- a/src/main/kotlin/me/kmozze/expensetracker/repository/ICategoryRepository.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/repository/ICategoryRepository.kt
@@ -6,6 +6,8 @@ import java.util.UUID
 interface ICategoryRepository {
     fun findById(id: UUID): Category?
 
+    fun findAllByUserId(userId: Long): List<Category>
+
     fun create(category: Category): Category
 
     fun update(category: Category): Category

--- a/src/main/kotlin/me/kmozze/expensetracker/repository/JooqCategoryRepository.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/repository/JooqCategoryRepository.kt
@@ -27,6 +27,14 @@ class JooqCategoryRepository(
             .fetchOne()
             ?.toDomain()
 
+    override fun findAllByUserId(userId: Long): List<Category> =
+        dsl
+            .selectFrom(CATEGORY)
+            .where(CATEGORY.USER_ID.eq(userId))
+            .orderBy(CATEGORY.NAME.asc())
+            .fetch()
+            .map { it.toDomain() }
+
     override fun create(category: Category): Category =
         dsl
             .insertInto(CATEGORY)

--- a/src/main/kotlin/me/kmozze/expensetracker/service/CategoryService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/CategoryService.kt
@@ -1,5 +1,6 @@
 package me.kmozze.expensetracker.service
 
+import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.exception.SystemErrorCode
 import me.kmozze.expensetracker.exception.exception
 import me.kmozze.expensetracker.model.entity.Category
@@ -55,5 +56,40 @@ class CategoryService(
                 cause = e,
             )
         }
+    }
+
+    fun getCategories(userId: Long): List<Category> =
+        try {
+            categoryRepository.findAllByUserId(userId)
+        } catch (e: DataAccessException) {
+            logger.error("Failed to load categories for user $userId", e)
+
+            throw SystemErrorCode.DATABASE_ERROR.exception(
+                customMessage = "Ошибка при получении категорий пользователя $userId",
+                cause = e,
+            )
+        }
+
+    fun getCategoryForUser(
+        categoryId: UUID,
+        userId: Long,
+    ): Category {
+        val category =
+            try {
+                categoryRepository.findById(categoryId)
+            } catch (e: DataAccessException) {
+                logger.error("Failed to load category $categoryId for user $userId", e)
+
+                throw SystemErrorCode.DATABASE_ERROR.exception(
+                    customMessage = "Ошибка при получении категории $categoryId",
+                    cause = e,
+                )
+            }
+
+        if (category == null || category.userId != userId) {
+            throw BusinessErrorCode.CATEGORY_NOT_FOUND.exception()
+        }
+
+        return category
     }
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/service/ExpenseService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/ExpenseService.kt
@@ -1,20 +1,53 @@
 package me.kmozze.expensetracker.service
 
+import me.kmozze.expensetracker.exception.SystemErrorCode
+import me.kmozze.expensetracker.exception.exception
 import me.kmozze.expensetracker.model.domain.ParsedExpense
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.repository.IExpenseRepository
 import me.kmozze.expensetracker.service.parser.InputExpenseParsingService
+import org.jooq.exception.DataAccessException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Service
 class ExpenseService(
     private val expenseTextParser: InputExpenseParsingService,
+    private val expenseRepository: IExpenseRepository,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun addExpense(text: String): ParsedExpense {
+    fun parseExpense(text: String): ParsedExpense {
         val parsedExpense = expenseTextParser.parse(text)
         logger.info("Expense parsed successfully: {}", parsedExpense)
 
         return parsedExpense
     }
+
+    @Transactional
+    fun saveExpense(
+        userId: Long,
+        categoryId: UUID,
+        parsedExpense: ParsedExpense,
+    ): Expense =
+        try {
+            val expense =
+                Expense(
+                    categoryId = categoryId,
+                    amount = parsedExpense.amount,
+                    userId = userId,
+                    description = parsedExpense.description,
+                )
+
+            expenseRepository.create(expense)
+        } catch (e: DataAccessException) {
+            logger.error("Failed to save expense for user $userId", e)
+
+            throw SystemErrorCode.DATABASE_ERROR.exception(
+                customMessage = "Ошибка при сохранении расхода пользователя $userId",
+                cause = e,
+            )
+        }
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/service/parser/InputExpenseParsingService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/parser/InputExpenseParsingService.kt
@@ -18,13 +18,13 @@ class InputExpenseParsingService {
 
         return when {
             amountFirst != null -> {
-                val category = words.drop(1).joinToString(" ")
-                createExpense(category, amountFirst)
+                val description = words.drop(1).joinToString(" ")
+                createExpense(description, amountFirst)
             }
 
             amountLast != null -> {
-                val category = words.dropLast(1).joinToString(" ")
-                createExpense(category, amountLast)
+                val description = words.dropLast(1).joinToString(" ")
+                createExpense(description, amountLast)
             }
 
             else -> throw BusinessErrorCode.EXPENSE_INVALID_FORMAT.exception()
@@ -39,12 +39,12 @@ class InputExpenseParsingService {
         }
 
     private fun createExpense(
-        category: String,
+        description: String,
         amount: BigDecimal,
     ): ParsedExpense {
         if (amount <= BigDecimal.ZERO) {
             throw BusinessErrorCode.INVALID_AMOUNT.exception()
         }
-        return ParsedExpense(category.trim(), amount)
+        return ParsedExpense(amount, description.trim())
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/AbstractIntegrationTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/AbstractIntegrationTest.kt
@@ -5,20 +5,17 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.junit.jupiter.Container
-import org.testcontainers.junit.jupiter.Testcontainers
 
-@Testcontainers
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @ActiveProfiles("test")
 abstract class AbstractIntegrationTest {
     companion object {
-        @Container
         val postgresContainer =
             PostgreSQLContainer("postgres:16-alpine")
                 .withDatabaseName("expense_test_db")
                 .withUsername("test_user")
                 .withPassword("test_password")
+                .apply { start() }
 
         @JvmStatic
         @DynamicPropertySource

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/handler/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/handler/AddExpenseFlowTest.kt
@@ -1,0 +1,88 @@
+package me.kmozze.expensetracker.integration.handler
+
+import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.handler.DialogueRouter
+import me.kmozze.expensetracker.integration.AbstractIntegrationTest
+import me.kmozze.expensetracker.model.domain.Action
+import me.kmozze.expensetracker.model.domain.Message
+import me.kmozze.expensetracker.model.domain.ParsedExpense
+import me.kmozze.expensetracker.model.domain.UserInput
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.repository.IExpenseRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+
+@Transactional
+class AddExpenseFlowTest : AbstractIntegrationTest() {
+    @Autowired
+    private lateinit var dialogueRouter: DialogueRouter
+
+    @Autowired
+    private lateinit var expenseRepository: IExpenseRepository
+
+    @Test
+    fun `add expense flow saves expense after category selection`() {
+        val userId = 2001L
+        val chatId = 3001L
+        val from = OffsetDateTime.now().minusMinutes(5)
+
+        dialogueRouter.process(UserInput(userId = userId, chatId = chatId, text = "/start"))
+
+        val addExpenseResult =
+            dialogueRouter.process(
+                UserInput(
+                    userId = userId,
+                    chatId = chatId,
+                    text = Buttons.ADD_EXPENSE,
+                ),
+            )
+
+        assertThat(addExpenseResult.response.message).isEqualTo(Message.AddExpenseInstructions)
+        assertThat(addExpenseResult.nextState).isEqualTo(UserState.AwaitingExpenseInput)
+
+        val parsedExpenseResult =
+            dialogueRouter.process(
+                UserInput(
+                    userId = userId,
+                    chatId = chatId,
+                    text = "500 такси",
+                ),
+            )
+        val categorySelectionAction = parsedExpenseResult.response.actions.single() as Action.ShowCategorySelection
+        val category = categorySelectionAction.categories.first()
+
+        assertThat(parsedExpenseResult.response.message)
+            .isEqualTo(Message.SelectCategory(BigDecimal("500"), "такси"))
+        assertThat(parsedExpenseResult.nextState)
+            .isEqualTo(UserState.AwaitingCategorySelection(ParsedExpense(BigDecimal("500"), "такси")))
+
+        val savedExpenseResult =
+            dialogueRouter.process(
+                UserInput(
+                    userId = userId,
+                    chatId = chatId,
+                    callbackData = "select_category:${category.id}",
+                ),
+            )
+
+        assertThat(savedExpenseResult.response.message)
+            .isEqualTo(Message.ExpenseSaved(BigDecimal("500.00"), category.name, "такси"))
+        assertThat(savedExpenseResult.nextState).isEqualTo(UserState.Idle)
+
+        val expenses =
+            expenseRepository.findAllByUserIdAndPeriod(
+                userId = userId,
+                from = from,
+                to = OffsetDateTime.now().plusMinutes(5),
+            )
+
+        assertThat(expenses).hasSize(1)
+        assertThat(expenses.single().amount).isEqualByComparingTo(BigDecimal("500"))
+        assertThat(expenses.single().categoryId).isEqualTo(category.id)
+        assertThat(expenses.single().description).isEqualTo("такси")
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
@@ -1,0 +1,108 @@
+package me.kmozze.expensetracker.unit.handler
+
+import io.mockk.mockk
+import me.kmozze.expensetracker.handler.DialogueRouter
+import me.kmozze.expensetracker.handler.ErrorHandler
+import me.kmozze.expensetracker.handler.StartCommandHandler
+import me.kmozze.expensetracker.handler.UnknownCommandHandler
+import me.kmozze.expensetracker.handler.statehandler.StateHandler
+import me.kmozze.expensetracker.model.domain.HandlerResponse
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Message
+import me.kmozze.expensetracker.model.domain.ParsedExpense
+import me.kmozze.expensetracker.model.domain.UserInput
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.service.UserSessionService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import kotlin.reflect.KClass
+
+class RoutingHandlerTest {
+    private val userSessionService = UserSessionService()
+    private val startCommandHandler: StartCommandHandler = mockk(relaxed = true)
+    private val unknownCommandHandler = UnknownCommandHandler()
+    private val errorHandler = ErrorHandler()
+
+    @Test
+    fun `routes awaiting category selection states with different payloads to the same handler`() {
+        val userId = 42L
+        val awaitingCategoryHandler = RecordingStateHandler(UserState.AwaitingCategorySelection::class)
+        val idleHandler = RecordingStateHandler(UserState.Idle::class)
+        val firstState =
+            UserState.AwaitingCategorySelection(
+                ParsedExpense(BigDecimal("500"), "такси"),
+            )
+        val secondState =
+            UserState.AwaitingCategorySelection(
+                ParsedExpense(BigDecimal("750"), "обед"),
+            )
+
+        val router =
+            routerWith(
+                idleHandler,
+                awaitingCategoryHandler,
+            )
+
+        val firstInput =
+            UserInput(
+                userId = userId,
+                chatId = 1L,
+                callbackData = "select_category:00000000-0000-0000-0000-000000000001",
+            )
+        val secondInput =
+            UserInput(
+                userId = userId,
+                chatId = 1L,
+                callbackData = "select_category:00000000-0000-0000-0000-000000000002",
+            )
+
+        userSessionService.setState(userId, firstState)
+        router.process(firstInput)
+        userSessionService.setState(userId, secondState)
+        router.process(secondInput)
+
+        assertThat(awaitingCategoryHandler.calls)
+            .extracting<UserInput> { it.input }
+            .containsExactly(firstInput, secondInput)
+        assertThat(awaitingCategoryHandler.calls)
+            .extracting<UserState> { it.currentState }
+            .containsExactly(firstState, secondState)
+        assertThat(idleHandler.calls).isEmpty()
+    }
+
+    private fun routerWith(vararg stateHandlers: StateHandler): DialogueRouter =
+        DialogueRouter(
+            userSessionService = userSessionService,
+            startCommandHandler = startCommandHandler,
+            unknownCommandHandler = unknownCommandHandler,
+            errorHandler = errorHandler,
+            stateHandlers = stateHandlers.toList(),
+        )
+
+    private class RecordingStateHandler(
+        override val supportedStateClass: KClass<out UserState>,
+    ) : StateHandler {
+        val calls = mutableListOf<Call>()
+
+        override fun handle(
+            input: UserInput,
+            currentState: UserState,
+        ): HandlerResult {
+            calls += Call(input, currentState)
+
+            return HandlerResult(
+                response =
+                    HandlerResponse(
+                        message = Message.FeatureInProgress,
+                        actions = emptyList(),
+                    ),
+            )
+        }
+    }
+
+    private data class Call(
+        val input: UserInput,
+        val currentState: UserState,
+    )
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/service/CategoryServiceTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/service/CategoryServiceTest.kt
@@ -58,6 +58,6 @@ class CategoryServiceTest {
                 service.initDefaultCategories(123L)
             }
 
-        assertEquals(SystemErrorCode.DATABASE_ERROR, exception.error)
+        assertEquals(SystemErrorCode.DATABASE_ERROR, exception.errorCode)
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/service/parser/InputExpenseParsingServiceTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/service/parser/InputExpenseParsingServiceTest.kt
@@ -17,12 +17,12 @@ class InputExpenseParsingServiceTest {
     @MethodSource("validInputs")
     fun `should parse valid inputs`(
         input: String,
-        expectedCategory: String,
+        expectedDescription: String,
         expectedAmount: BigDecimal,
     ) {
         val result = service.parse(input)
 
-        Assertions.assertThat(result.category).isEqualTo(expectedCategory)
+        Assertions.assertThat(result.description).isEqualTo(expectedDescription)
         Assertions.assertThat(result.amount).isEqualByComparingTo(expectedAmount)
     }
 
@@ -32,7 +32,7 @@ class InputExpenseParsingServiceTest {
         Assertions
             .assertThatThrownBy { service.parse(input) }
             .isInstanceOf(BusinessException::class.java)
-            .extracting("error")
+            .extracting("errorCode")
             .isEqualTo(BusinessErrorCode.EXPENSE_INVALID_FORMAT)
     }
 
@@ -42,7 +42,7 @@ class InputExpenseParsingServiceTest {
         Assertions
             .assertThatThrownBy { service.parse(input) }
             .isInstanceOf(BusinessException::class.java)
-            .extracting("error")
+            .extracting("errorCode")
             .isEqualTo(BusinessErrorCode.INVALID_AMOUNT)
     }
 


### PR DESCRIPTION
## Что сделано
- Добавлен state flow: главное меню -> ввод расхода -> выбор категории -> сохранение.
- Добавлено получение категорий пользователя и сохранение расхода через jOOQ repository.
- Добавлены regression-тест роутинга по классу состояния и integration happy path добавления расхода.
- Обновлены parser/service тесты под ParsedExpense.description и errorCode.

## Что не сделано сознательно
- Просмотр расходов, категории и статистика остаются заглушками.
- Edit/delete сохраненного расхода будет отдельной задачей.

## Как тестировать
- ./gradlew ktlintCheck test