### PR TITLE
add expense service support

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/ParsedExpense.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/ParsedExpense.kt
@@ -3,7 +3,6 @@ package me.kmozze.expensetracker.model.domain
 import java.math.BigDecimal
 
 data class ParsedExpense(
-    val category: String,
     val amount: BigDecimal,
-    val description: String? = null,
+    val description: String,
 )

--- a/src/main/kotlin/me/kmozze/expensetracker/repository/ICategoryRepository.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/repository/ICategoryRepository.kt
@@ -6,6 +6,8 @@ import java.util.UUID
 interface ICategoryRepository {
     fun findById(id: UUID): Category?
 
+    fun findAllByUserId(userId: Long): List<Category>
+
     fun create(category: Category): Category
 
     fun update(category: Category): Category

--- a/src/main/kotlin/me/kmozze/expensetracker/repository/JooqCategoryRepository.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/repository/JooqCategoryRepository.kt
@@ -27,6 +27,14 @@ class JooqCategoryRepository(
             .fetchOne()
             ?.toDomain()
 
+    override fun findAllByUserId(userId: Long): List<Category> =
+        dsl
+            .selectFrom(CATEGORY)
+            .where(CATEGORY.USER_ID.eq(userId))
+            .orderBy(CATEGORY.NAME.asc())
+            .fetch()
+            .map { it.toDomain() }
+
     override fun create(category: Category): Category =
         dsl
             .insertInto(CATEGORY)

--- a/src/main/kotlin/me/kmozze/expensetracker/service/CategoryService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/CategoryService.kt
@@ -1,5 +1,6 @@
 package me.kmozze.expensetracker.service
 
+import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.exception.SystemErrorCode
 import me.kmozze.expensetracker.exception.exception
 import me.kmozze.expensetracker.model.entity.Category
@@ -55,5 +56,40 @@ class CategoryService(
                 cause = e,
             )
         }
+    }
+
+    fun getCategories(userId: Long): List<Category> =
+        try {
+            categoryRepository.findAllByUserId(userId)
+        } catch (e: DataAccessException) {
+            logger.error("Failed to load categories for user $userId", e)
+
+            throw SystemErrorCode.DATABASE_ERROR.exception(
+                customMessage = "Ошибка при получении категорий пользователя $userId",
+                cause = e,
+            )
+        }
+
+    fun getCategoryForUser(
+        categoryId: UUID,
+        userId: Long,
+    ): Category {
+        val category =
+            try {
+                categoryRepository.findById(categoryId)
+            } catch (e: DataAccessException) {
+                logger.error("Failed to load category $categoryId for user $userId", e)
+
+                throw SystemErrorCode.DATABASE_ERROR.exception(
+                    customMessage = "Ошибка при получении категории $categoryId",
+                    cause = e,
+                )
+            }
+
+        if (category == null || category.userId != userId) {
+            throw BusinessErrorCode.CATEGORY_NOT_FOUND.exception()
+        }
+
+        return category
     }
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/service/ExpenseService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/ExpenseService.kt
@@ -1,20 +1,53 @@
 package me.kmozze.expensetracker.service
 
+import me.kmozze.expensetracker.exception.SystemErrorCode
+import me.kmozze.expensetracker.exception.exception
 import me.kmozze.expensetracker.model.domain.ParsedExpense
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.repository.IExpenseRepository
 import me.kmozze.expensetracker.service.parser.InputExpenseParsingService
+import org.jooq.exception.DataAccessException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
 
 @Service
 class ExpenseService(
     private val expenseTextParser: InputExpenseParsingService,
+    private val expenseRepository: IExpenseRepository,
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun addExpense(text: String): ParsedExpense {
+    fun parseExpense(text: String): ParsedExpense {
         val parsedExpense = expenseTextParser.parse(text)
         logger.info("Expense parsed successfully: {}", parsedExpense)
 
         return parsedExpense
     }
+
+    @Transactional
+    fun saveExpense(
+        userId: Long,
+        categoryId: UUID,
+        parsedExpense: ParsedExpense,
+    ): Expense =
+        try {
+            val expense =
+                Expense(
+                    categoryId = categoryId,
+                    amount = parsedExpense.amount,
+                    userId = userId,
+                    description = parsedExpense.description,
+                )
+
+            expenseRepository.create(expense)
+        } catch (e: DataAccessException) {
+            logger.error("Failed to save expense for user $userId", e)
+
+            throw SystemErrorCode.DATABASE_ERROR.exception(
+                customMessage = "Ошибка при сохранении расхода пользователя $userId",
+                cause = e,
+            )
+        }
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/service/parser/InputExpenseParsingService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/parser/InputExpenseParsingService.kt
@@ -18,13 +18,13 @@ class InputExpenseParsingService {
 
         return when {
             amountFirst != null -> {
-                val category = words.drop(1).joinToString(" ")
-                createExpense(category, amountFirst)
+                val description = words.drop(1).joinToString(" ")
+                createExpense(description, amountFirst)
             }
 
             amountLast != null -> {
-                val category = words.dropLast(1).joinToString(" ")
-                createExpense(category, amountLast)
+                val description = words.dropLast(1).joinToString(" ")
+                createExpense(description, amountLast)
             }
 
             else -> throw BusinessErrorCode.EXPENSE_INVALID_FORMAT.exception()
@@ -39,12 +39,12 @@ class InputExpenseParsingService {
         }
 
     private fun createExpense(
-        category: String,
+        description: String,
         amount: BigDecimal,
     ): ParsedExpense {
         if (amount <= BigDecimal.ZERO) {
             throw BusinessErrorCode.INVALID_AMOUNT.exception()
         }
-        return ParsedExpense(category.trim(), amount)
+        return ParsedExpense(amount, description.trim())
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/service/CategoryServiceTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/service/CategoryServiceTest.kt
@@ -58,6 +58,6 @@ class CategoryServiceTest {
                 service.initDefaultCategories(123L)
             }
 
-        assertEquals(SystemErrorCode.DATABASE_ERROR, exception.error)
+        assertEquals(SystemErrorCode.DATABASE_ERROR, exception.errorCode)
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/service/parser/InputExpenseParsingServiceTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/service/parser/InputExpenseParsingServiceTest.kt
@@ -17,12 +17,12 @@ class InputExpenseParsingServiceTest {
     @MethodSource("validInputs")
     fun `should parse valid inputs`(
         input: String,
-        expectedCategory: String,
+        expectedDescription: String,
         expectedAmount: BigDecimal,
     ) {
         val result = service.parse(input)
 
-        Assertions.assertThat(result.category).isEqualTo(expectedCategory)
+        Assertions.assertThat(result.description).isEqualTo(expectedDescription)
         Assertions.assertThat(result.amount).isEqualByComparingTo(expectedAmount)
     }
 
@@ -32,7 +32,7 @@ class InputExpenseParsingServiceTest {
         Assertions
             .assertThatThrownBy { service.parse(input) }
             .isInstanceOf(BusinessException::class.java)
-            .extracting("error")
+            .extracting("errorCode")
             .isEqualTo(BusinessErrorCode.EXPENSE_INVALID_FORMAT)
     }
 
@@ -42,7 +42,7 @@ class InputExpenseParsingServiceTest {
         Assertions
             .assertThatThrownBy { service.parse(input) }
             .isInstanceOf(BusinessException::class.java)
-            .extracting("error")
+            .extracting("errorCode")
             .isEqualTo(BusinessErrorCode.INVALID_AMOUNT)
     }
 


### PR DESCRIPTION
## Что сделано
- добавлены сервисные методы для получения категорий пользователя и проверки категории
- добавлено сохранение расхода через ExpenseService
- обновлен парсер ParsedExpense и unit-тесты вокруг parsing/category service

## Что не сделано сознательно
- без Telegram/state-flow обработчиков
- без интеграционных flow-тестов

## Как тестировать
- ./gradlew ktlintCheck test