### PR TITLE
add expense state flow

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/handler/DialogueRouter.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/DialogueRouter.kt
@@ -28,9 +28,9 @@ class DialogueRouter(
 
             val currentState = userSessionService.getState(input.userId)
 
-            val handler = handlersByState[currentState::class] ?: unknownCommandHandler
+            val handler = handlersByState[currentState::class]
 
-            val result = handler.handle(input)
+            val result = handler?.handle(input, currentState) ?: unknownCommandHandler.handle(input)
 
             if (result.nextState != null) {
                 userSessionService.setState(input.userId, result.nextState)

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
@@ -1,0 +1,110 @@
+package me.kmozze.expensetracker.handler.statehandler
+
+import me.kmozze.expensetracker.exception.BusinessErrorCode
+import me.kmozze.expensetracker.model.domain.Action
+import me.kmozze.expensetracker.model.domain.HandlerResponse
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Message
+import me.kmozze.expensetracker.model.domain.UserInput
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import org.springframework.stereotype.Component
+import java.util.UUID
+import kotlin.reflect.KClass
+
+@Component
+class AwaitingCategorySelectionHandler(
+    private val categoryService: CategoryService,
+    private val expenseService: ExpenseService,
+) : StateHandler {
+    override val supportedStateClass: KClass<out UserState> = UserState.AwaitingCategorySelection::class
+
+    override fun handle(
+        input: UserInput,
+        currentState: UserState,
+    ): HandlerResult {
+        require(currentState is UserState.AwaitingCategorySelection) {
+            "AwaitingCategorySelectionHandler requires AwaitingCategorySelection state"
+        }
+
+        val callbackData = input.callbackData
+
+        if (callbackData == CANCEL_CALLBACK) {
+            return HandlerResult(
+                response =
+                    HandlerResponse(
+                        message = Message.ExpenseCanceled,
+                        actions = listOf(Action.ShowMainMenu),
+                    ),
+                nextState = UserState.Idle,
+            )
+        }
+
+        if (callbackData == null || !callbackData.startsWith(SELECT_CATEGORY_PREFIX)) {
+            val categories = categoryService.getCategories(input.userId)
+            return HandlerResult(
+                response =
+                    HandlerResponse(
+                        message =
+                            Message.SelectCategory(
+                                amount = currentState.parsedExpense.amount,
+                                description = currentState.parsedExpense.description,
+                            ),
+                        actions = listOf(Action.ShowCategorySelection(categories)),
+                    ),
+                nextState = currentState,
+            )
+        }
+
+        val categoryId =
+            callbackData
+                .removePrefix(SELECT_CATEGORY_PREFIX)
+                .let { runCatching { UUID.fromString(it) }.getOrNull() }
+                ?: return invalidCategorySelection(input.userId, currentState)
+
+        val category = categoryService.getCategoryForUser(categoryId, input.userId)
+
+        val expense =
+            expenseService.saveExpense(
+                userId = input.userId,
+                categoryId = category.id,
+                parsedExpense = currentState.parsedExpense,
+            )
+
+        return HandlerResult(
+            response =
+                HandlerResponse(
+                    message =
+                        Message.ExpenseSaved(
+                            amount = expense.amount,
+                            categoryName = category.name,
+                            description = expense.description.orEmpty(),
+                        ),
+                    actions = listOf(Action.ShowMainMenu),
+                ),
+            nextState = UserState.Idle,
+        )
+    }
+
+    private fun invalidCategorySelection(
+        userId: Long,
+        currentState: UserState.AwaitingCategorySelection,
+    ): HandlerResult {
+        val categories = categoryService.getCategories(userId)
+
+        return HandlerResult(
+            response =
+                HandlerResponse(
+                    message = Message.Error(BusinessErrorCode.INVALID_CATEGORY_SELECTION),
+                    actions = listOf(Action.ShowCategorySelection(categories)),
+                ),
+            nextState = currentState,
+        )
+    }
+
+    private companion object {
+        const val SELECT_CATEGORY_PREFIX = "select_category:"
+        const val CANCEL_CALLBACK = "cancel"
+    }
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseInputHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseInputHandler.kt
@@ -1,0 +1,90 @@
+package me.kmozze.expensetracker.handler.statehandler
+
+import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.exception.BusinessException
+import me.kmozze.expensetracker.model.domain.Action
+import me.kmozze.expensetracker.model.domain.HandlerResponse
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Message
+import me.kmozze.expensetracker.model.domain.UserInput
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import org.springframework.stereotype.Component
+import kotlin.reflect.KClass
+
+@Component
+class AwaitingExpenseInputHandler(
+    private val expenseService: ExpenseService,
+    private val categoryService: CategoryService,
+) : StateHandler {
+    override val supportedStateClass: KClass<out UserState> = UserState.AwaitingExpenseInput::class
+
+    override fun handle(input: UserInput): HandlerResult {
+        if (input.text == Buttons.ADD_EXPENSE) {
+            return HandlerResult(
+                response =
+                    HandlerResponse(
+                        message = Message.AddExpenseInstructions,
+                        actions = listOf(Action.ShowMainMenu),
+                    ),
+                nextState = UserState.AwaitingExpenseInput,
+            )
+        }
+
+        if (input.text in setOf(Buttons.VIEW_EXPENSES, Buttons.CATEGORIES, Buttons.STATISTICS)) {
+            return HandlerResult(
+                response =
+                    HandlerResponse(
+                        message = Message.FeatureInProgress,
+                        actions = listOf(Action.ShowMainMenu),
+                    ),
+                nextState = UserState.Idle,
+            )
+        }
+
+        val text =
+            input.text
+                ?: return HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = Message.AddExpenseInstructions,
+                            actions = listOf(Action.ShowMainMenu),
+                        ),
+                    nextState = UserState.AwaitingExpenseInput,
+                )
+
+        val parsedExpense =
+            try {
+                expenseService.parseExpense(text)
+            } catch (e: BusinessException) {
+                return HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = Message.Error(e.errorCode),
+                            actions = listOf(Action.ShowMainMenu),
+                        ),
+                    nextState = UserState.AwaitingExpenseInput,
+                )
+            }
+
+        var categories = categoryService.getCategories(input.userId)
+        if (categories.isEmpty()) {
+            categoryService.initDefaultCategories(input.userId)
+            categories = categoryService.getCategories(input.userId)
+        }
+
+        return HandlerResult(
+            response =
+                HandlerResponse(
+                    message =
+                        Message.SelectCategory(
+                            amount = parsedExpense.amount,
+                            description = parsedExpense.description,
+                        ),
+                    actions = listOf(Action.ShowCategorySelection(categories)),
+                ),
+            nextState = UserState.AwaitingCategorySelection(parsedExpense),
+        )
+    }
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/IdleStateHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/IdleStateHandler.kt
@@ -1,0 +1,52 @@
+package me.kmozze.expensetracker.handler.statehandler
+
+import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.model.domain.Action
+import me.kmozze.expensetracker.model.domain.HandlerResponse
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Message
+import me.kmozze.expensetracker.model.domain.UserInput
+import me.kmozze.expensetracker.model.domain.UserState
+import org.springframework.stereotype.Component
+import kotlin.reflect.KClass
+
+@Component
+class IdleStateHandler : StateHandler {
+    override val supportedStateClass: KClass<out UserState> = UserState.Idle::class
+
+    override fun handle(input: UserInput): HandlerResult =
+        when (input.text) {
+            Buttons.ADD_EXPENSE ->
+                HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = Message.AddExpenseInstructions,
+                            actions = listOf(Action.ShowMainMenu),
+                        ),
+                    nextState = UserState.AwaitingExpenseInput,
+                )
+
+            Buttons.VIEW_EXPENSES,
+            Buttons.CATEGORIES,
+            Buttons.STATISTICS,
+            ->
+                HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = Message.FeatureInProgress,
+                            actions = listOf(Action.ShowMainMenu),
+                        ),
+                    nextState = UserState.Idle,
+                )
+
+            else ->
+                HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = Message.UnknownCommand,
+                            actions = listOf(Action.ShowMainMenu),
+                        ),
+                    nextState = UserState.Idle,
+                )
+        }
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/StateHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/StateHandler.kt
@@ -1,9 +1,19 @@
 package me.kmozze.expensetracker.handler.statehandler
 
 import me.kmozze.expensetracker.handler.UserInputHandler
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.UserInput
 import me.kmozze.expensetracker.model.domain.UserState
 import kotlin.reflect.KClass
 
 interface StateHandler : UserInputHandler {
     val supportedStateClass: KClass<out UserState>
+
+    override fun handle(input: UserInput): HandlerResult =
+        throw IllegalStateException("${this::class.simpleName} requires current user state")
+
+    fun handle(
+        input: UserInput,
+        currentState: UserState,
+    ): HandlerResult = handle(input)
 }


### PR DESCRIPTION
## Что сделано
- добавлены state handlers для ввода расхода и выбора категории
- DialogueRouter теперь передает текущий UserState в state handler
- добавлен переход Idle -> AwaitingExpenseInput -> AwaitingCategorySelection -> Idle

## Что не сделано сознательно
- без тестовой инфраструктуры и новых flow-тестов
- опирается на сервисный слой из предыдущего PR

## Как тестировать
- ./gradlew ktlintCheck test