### PR TITLE
test: harden add expense flow coverage

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
@@ -1,6 +1,7 @@
 package me.kmozze.expensetracker.handler.statehandler
 
 import me.kmozze.expensetracker.exception.BusinessErrorCode
+import me.kmozze.expensetracker.exception.BusinessException
 import me.kmozze.expensetracker.model.domain.Action
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.HandlerResult
@@ -63,7 +64,20 @@ class AwaitingCategorySelectionHandler(
                 .let { runCatching { UUID.fromString(it) }.getOrNull() }
                 ?: return invalidCategorySelection(input.userId, currentState)
 
-        val category = categoryService.getCategoryForUser(categoryId, input.userId)
+        val category =
+            try {
+                categoryService.getCategoryForUser(categoryId, input.userId)
+            } catch (e: BusinessException) {
+                if (e.errorCode == BusinessErrorCode.CATEGORY_NOT_FOUND) {
+                    return categorySelectionError(
+                        userId = input.userId,
+                        currentState = currentState,
+                        errorCode = BusinessErrorCode.CATEGORY_NOT_FOUND,
+                    )
+                }
+
+                throw e
+            }
 
         val expense =
             expenseService.saveExpense(
@@ -90,13 +104,24 @@ class AwaitingCategorySelectionHandler(
     private fun invalidCategorySelection(
         userId: Long,
         currentState: UserState.AwaitingCategorySelection,
+    ): HandlerResult =
+        categorySelectionError(
+            userId = userId,
+            currentState = currentState,
+            errorCode = BusinessErrorCode.INVALID_CATEGORY_SELECTION,
+        )
+
+    private fun categorySelectionError(
+        userId: Long,
+        currentState: UserState.AwaitingCategorySelection,
+        errorCode: BusinessErrorCode,
     ): HandlerResult {
         val categories = categoryService.getCategories(userId)
 
         return HandlerResult(
             response =
                 HandlerResponse(
-                    message = Message.Error(BusinessErrorCode.INVALID_CATEGORY_SELECTION),
+                    message = Message.Error(errorCode),
                     actions = listOf(Action.ShowCategorySelection(categories)),
                 ),
             nextState = currentState,

--- a/src/main/kotlin/me/kmozze/expensetracker/service/UserSessionService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/UserSessionService.kt
@@ -14,6 +14,10 @@ class UserSessionService {
         sessions.remove(userId)
     }
 
+    fun clearAll() {
+        sessions.clear()
+    }
+
     fun setState(
         userId: Long,
         state: UserState,

--- a/src/main/kotlin/me/kmozze/expensetracker/service/UserSessionService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/UserSessionService.kt
@@ -14,6 +14,9 @@ class UserSessionService {
         sessions.remove(userId)
     }
 
+    /**
+     * Test-only helper for isolating integration tests that share the Spring context.
+     */
     fun clearAll() {
         sessions.clear()
     }

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/AbstractIntegrationTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/AbstractIntegrationTest.kt
@@ -1,5 +1,8 @@
 package me.kmozze.expensetracker.integration
 
+import me.kmozze.expensetracker.service.UserSessionService
+import org.junit.jupiter.api.AfterEach
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
@@ -9,6 +12,14 @@ import org.testcontainers.containers.PostgreSQLContainer
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @ActiveProfiles("test")
 abstract class AbstractIntegrationTest {
+    @Autowired
+    private lateinit var userSessionService: UserSessionService
+
+    @AfterEach
+    fun clearUserSessions() {
+        userSessionService.clearAll()
+    }
+
     companion object {
         val postgresContainer =
             PostgreSQLContainer("postgres:16-alpine")

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/handler/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/handler/AddExpenseFlowTest.kt
@@ -135,9 +135,10 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
     }
 
     @Test
-    fun `foreign category callback returns category not found without saving expense`() {
+    fun `foreign category callback keeps category selection open without saving expense`() {
         val userId = 2004L
         val chatId = 3004L
+        val parsedExpense = startCategorySelection(userId, chatId)
         val foreignCategory =
             categoryRepository.create(
                 Category(
@@ -146,8 +147,6 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
                     userId = 9999L,
                 ),
             )
-
-        startCategorySelection(userId, chatId)
 
         val result =
             dialogueRouter.process(
@@ -159,7 +158,8 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
             )
 
         assertThat(result.response.message).isEqualTo(Message.Error(BusinessErrorCode.CATEGORY_NOT_FOUND))
-        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        assertThat(result.response.actions.single()).isInstanceOf(Action.ShowCategorySelection::class.java)
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingCategorySelection(parsedExpense))
         assertThat(findExpenses(userId)).isEmpty()
     }
 

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/handler/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/handler/AddExpenseFlowTest.kt
@@ -1,6 +1,7 @@
 package me.kmozze.expensetracker.integration.handler
 
 import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.handler.DialogueRouter
 import me.kmozze.expensetracker.integration.AbstractIntegrationTest
 import me.kmozze.expensetracker.model.domain.Action
@@ -8,6 +9,9 @@ import me.kmozze.expensetracker.model.domain.Message
 import me.kmozze.expensetracker.model.domain.ParsedExpense
 import me.kmozze.expensetracker.model.domain.UserInput
 import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.repository.ICategoryRepository
 import me.kmozze.expensetracker.repository.IExpenseRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -15,11 +19,15 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.time.OffsetDateTime
+import java.util.UUID
 
 @Transactional
 class AddExpenseFlowTest : AbstractIntegrationTest() {
     @Autowired
     private lateinit var dialogueRouter: DialogueRouter
+
+    @Autowired
+    private lateinit var categoryRepository: ICategoryRepository
 
     @Autowired
     private lateinit var expenseRepository: IExpenseRepository
@@ -28,7 +36,6 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
     fun `add expense flow saves expense after category selection`() {
         val userId = 2001L
         val chatId = 3001L
-        val from = OffsetDateTime.now().minusMinutes(5)
 
         dialogueRouter.process(UserInput(userId = userId, chatId = chatId, text = "/start"))
 
@@ -53,6 +60,8 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
                 ),
             )
         val categorySelectionAction = parsedExpenseResult.response.actions.single() as Action.ShowCategorySelection
+
+        assertThat(categorySelectionAction.categories).isNotEmpty()
         val category = categorySelectionAction.categories.first()
 
         assertThat(parsedExpenseResult.response.message)
@@ -74,15 +83,161 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
         assertThat(savedExpenseResult.nextState).isEqualTo(UserState.Idle)
 
         val expenses =
-            expenseRepository.findAllByUserIdAndPeriod(
-                userId = userId,
-                from = from,
-                to = OffsetDateTime.now().plusMinutes(5),
-            )
+            findExpenses(userId)
 
         assertThat(expenses).hasSize(1)
         assertThat(expenses.single().amount).isEqualByComparingTo(BigDecimal("500"))
         assertThat(expenses.single().categoryId).isEqualTo(category.id)
         assertThat(expenses.single().description).isEqualTo("такси")
+    }
+
+    @Test
+    fun `cancel category selection returns to idle without saving expense`() {
+        val userId = 2002L
+        val chatId = 3002L
+
+        startCategorySelection(userId, chatId)
+
+        val result =
+            dialogueRouter.process(
+                UserInput(
+                    userId = userId,
+                    chatId = chatId,
+                    callbackData = "cancel",
+                ),
+            )
+
+        assertThat(result.response.message).isEqualTo(Message.ExpenseCanceled)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        assertThat(findExpenses(userId)).isEmpty()
+    }
+
+    @Test
+    fun `invalid category callback keeps category selection open without saving expense`() {
+        val userId = 2003L
+        val chatId = 3003L
+
+        val parsedExpense = startCategorySelection(userId, chatId)
+
+        val result =
+            dialogueRouter.process(
+                UserInput(
+                    userId = userId,
+                    chatId = chatId,
+                    callbackData = "select_category:not-a-uuid",
+                ),
+            )
+
+        assertThat(result.response.message).isEqualTo(Message.Error(BusinessErrorCode.INVALID_CATEGORY_SELECTION))
+        assertThat(result.response.actions.single()).isInstanceOf(Action.ShowCategorySelection::class.java)
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingCategorySelection(parsedExpense))
+        assertThat(findExpenses(userId)).isEmpty()
+    }
+
+    @Test
+    fun `foreign category callback returns category not found without saving expense`() {
+        val userId = 2004L
+        val chatId = 3004L
+        val foreignCategory =
+            categoryRepository.create(
+                Category(
+                    id = UUID.randomUUID(),
+                    name = "Чужая",
+                    userId = 9999L,
+                ),
+            )
+
+        startCategorySelection(userId, chatId)
+
+        val result =
+            dialogueRouter.process(
+                UserInput(
+                    userId = userId,
+                    chatId = chatId,
+                    callbackData = "select_category:${foreignCategory.id}",
+                ),
+            )
+
+        assertThat(result.response.message).isEqualTo(Message.Error(BusinessErrorCode.CATEGORY_NOT_FOUND))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        assertThat(findExpenses(userId)).isEmpty()
+    }
+
+    @Test
+    fun `parse error keeps awaiting expense input without saving expense`() {
+        val userId = 2005L
+        val chatId = 3005L
+
+        dialogueRouter.process(UserInput(userId = userId, chatId = chatId, text = "/start"))
+        dialogueRouter.process(UserInput(userId = userId, chatId = chatId, text = Buttons.ADD_EXPENSE))
+
+        val result =
+            dialogueRouter.process(
+                UserInput(
+                    userId = userId,
+                    chatId = chatId,
+                    text = "такси",
+                ),
+            )
+
+        assertThat(result.response.message).isEqualTo(Message.Error(BusinessErrorCode.EXPENSE_INVALID_FORMAT))
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingExpenseInput)
+        assertThat(findExpenses(userId)).isEmpty()
+    }
+
+    @Test
+    fun `start command in the middle of add expense flow resets state without saving expense`() {
+        val userId = 2006L
+        val chatId = 3006L
+
+        startCategorySelection(userId, chatId)
+
+        val result =
+            dialogueRouter.process(
+                UserInput(
+                    userId = userId,
+                    chatId = chatId,
+                    text = "/start",
+                ),
+            )
+
+        assertThat(result.response.message).isEqualTo(Message.WelcomeBack)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        assertThat(findExpenses(userId)).isEmpty()
+    }
+
+    private fun startCategorySelection(
+        userId: Long,
+        chatId: Long,
+    ): ParsedExpense {
+        dialogueRouter.process(UserInput(userId = userId, chatId = chatId, text = "/start"))
+        dialogueRouter.process(UserInput(userId = userId, chatId = chatId, text = Buttons.ADD_EXPENSE))
+
+        val result =
+            dialogueRouter.process(
+                UserInput(
+                    userId = userId,
+                    chatId = chatId,
+                    text = "500 такси",
+                ),
+            )
+        val categorySelectionAction = result.response.actions.single() as Action.ShowCategorySelection
+
+        assertThat(result.response.message).isEqualTo(Message.SelectCategory(BigDecimal("500"), "такси"))
+        assertThat(categorySelectionAction.categories).isNotEmpty()
+
+        return ParsedExpense(BigDecimal("500"), "такси")
+    }
+
+    private fun findExpenses(userId: Long): List<Expense> =
+        expenseRepository.findAllByUserIdAndPeriod(
+            userId = userId,
+            from = TEST_PERIOD_FROM,
+            to = TEST_PERIOD_TO,
+        )
+
+    private companion object {
+        val TEST_PERIOD_FROM: OffsetDateTime = OffsetDateTime.parse("2000-01-01T00:00:00Z")
+        val TEST_PERIOD_TO: OffsetDateTime = OffsetDateTime.parse("2100-01-01T00:00:00Z")
     }
 }


### PR DESCRIPTION
## Что сделано

- Добавлена очистка in-memory user sessions между integration-тестами.
- Усилен add-expense flow: добавлены негативные сценарии для cancel, invalid UUID, чужой категории, parse error и /start посередине flow.
- Чужая/несуществующая категория во время выбора теперь оставляет пользователя на выборе категории, как и invalid UUID.
- Убрана wall-clock зависимость из проверки сохраненного расхода.

## Как проверить

Локально пройдены `ktlintCheck`, `compileKotlin`, focused `AddExpenseFlowTest` и полный `test`.