### PR TITLE
refactor: introduce Money value object

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/MessageFormatter.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/MessageFormatter.kt
@@ -23,11 +23,11 @@ class MessageFormatter {
                 "Введите сумму и описание одним сообщением.\nНапример: `500 такси` или  `такси 500`."
 
             is BotMessage.SelectCategory ->
-                "💰 *${message.amount} ₽*\n📝 ${message.description}\n\nКуда запишем?"
+                "💰 *${message.amount.format()} ₽*\n📝 ${message.description}\n\nКуда запишем?"
 
             is BotMessage.ExpenseSaved ->
                 "✅ Сохранено!\n" +
-                    "💰 Сумма: ${message.amount} ₽\n" +
+                    "💰 Сумма: ${message.amount.format()} ₽\n" +
                     "📂 Категория: ${message.categoryName}\n" +
                     "📝 Описание: ${message.description}"
 

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/BotMessage.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/BotMessage.kt
@@ -1,7 +1,6 @@
 package me.kmozze.expensetracker.model.domain
 
 import me.kmozze.expensetracker.exception.ErrorCode
-import java.math.BigDecimal
 
 sealed class BotMessage {
     data object WelcomeFirstTime : BotMessage()
@@ -13,12 +12,12 @@ sealed class BotMessage {
     data object AddExpenseInstructions : BotMessage()
 
     data class SelectCategory(
-        val amount: BigDecimal,
+        val amount: Money,
         val description: String?,
     ) : BotMessage()
 
     data class ExpenseSaved(
-        val amount: BigDecimal,
+        val amount: Money,
         val categoryName: String,
         val description: String,
     ) : BotMessage()

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/Money.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/Money.kt
@@ -1,0 +1,18 @@
+package me.kmozze.expensetracker.model.domain
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+private const val MONEY_SCALE = 2
+private val MONEY_ROUNDING_MODE = RoundingMode.HALF_UP
+
+@JvmInline
+value class Money private constructor(
+    val value: BigDecimal,
+) {
+    fun format(): String = value.toPlainString()
+
+    companion object {
+        fun of(value: BigDecimal): Money = Money(value.setScale(MONEY_SCALE, MONEY_ROUNDING_MODE))
+    }
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/ParsedExpense.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/ParsedExpense.kt
@@ -1,8 +1,6 @@
 package me.kmozze.expensetracker.model.domain
 
-import java.math.BigDecimal
-
 data class ParsedExpense(
-    val amount: BigDecimal,
+    val amount: Money,
     val description: String,
 )

--- a/src/main/kotlin/me/kmozze/expensetracker/model/entity/Expense.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/entity/Expense.kt
@@ -1,13 +1,13 @@
 package me.kmozze.expensetracker.model.entity
 
-import java.math.BigDecimal
+import me.kmozze.expensetracker.model.domain.Money
 import java.time.OffsetDateTime
 import java.util.UUID
 
 data class Expense(
     val id: UUID = UUID.randomUUID(),
     val categoryId: UUID,
-    val amount: BigDecimal,
+    val amount: Money,
     val userId: Long,
     val description: String? = null,
     val createdAt: OffsetDateTime? = null,

--- a/src/main/kotlin/me/kmozze/expensetracker/repository/JooqExpenseRepository.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/repository/JooqExpenseRepository.kt
@@ -2,6 +2,7 @@ package me.kmozze.expensetracker.repository
 
 import me.kmozze.expense.tracker.jooq.tables.records.ExpenseRecord
 import me.kmozze.expense.tracker.jooq.tables.references.EXPENSE
+import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.entity.Expense
 import org.jooq.DSLContext
 import org.springframework.stereotype.Repository
@@ -16,7 +17,7 @@ class JooqExpenseRepository(
         Expense(
             id = this.id,
             categoryId = this.categoryId,
-            amount = this.amount,
+            amount = Money.of(this.amount),
             userId = this.userId,
             description = this.description,
             createdAt = this.createdAt,
@@ -33,7 +34,7 @@ class JooqExpenseRepository(
         dsl
             .insertInto(EXPENSE)
             .set(EXPENSE.ID, expense.id)
-            .set(EXPENSE.AMOUNT, expense.amount)
+            .set(EXPENSE.AMOUNT, expense.amount.value)
             .set(EXPENSE.CATEGORY_ID, expense.categoryId)
             .set(EXPENSE.USER_ID, expense.userId)
             .set(EXPENSE.DESCRIPTION, expense.description)
@@ -44,7 +45,7 @@ class JooqExpenseRepository(
     override fun update(expense: Expense): Expense =
         dsl
             .update(EXPENSE)
-            .set(EXPENSE.AMOUNT, expense.amount)
+            .set(EXPENSE.AMOUNT, expense.amount.value)
             .set(EXPENSE.CATEGORY_ID, expense.categoryId)
             .set(EXPENSE.DESCRIPTION, expense.description)
             .where(EXPENSE.ID.eq(expense.id))

--- a/src/main/kotlin/me/kmozze/expensetracker/service/parser/InputExpenseParsingService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/parser/InputExpenseParsingService.kt
@@ -2,6 +2,7 @@ package me.kmozze.expensetracker.service.parser
 
 import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.exception.exception
+import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.ParsedExpense
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -42,9 +43,11 @@ class InputExpenseParsingService {
         description: String,
         amount: BigDecimal,
     ): ParsedExpense {
-        if (amount <= BigDecimal.ZERO) {
+        val money = Money.of(amount)
+
+        if (money.value <= BigDecimal.ZERO) {
             throw BusinessErrorCode.INVALID_AMOUNT.exception()
         }
-        return ParsedExpense(amount, description.trim())
+        return ParsedExpense(money, description.trim())
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/handler/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/handler/AddExpenseFlowTest.kt
@@ -8,6 +8,7 @@ import me.kmozze.expensetracker.handler.DialogueRouter
 import me.kmozze.expensetracker.integration.AbstractIntegrationTest
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotMessage
+import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.ParsedExpense
 import me.kmozze.expensetracker.model.domain.UserInput
 import me.kmozze.expensetracker.model.domain.UserState
@@ -67,9 +68,9 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
         val category = categorySelectionAction.categories.first()
 
         assertThat(parsedExpenseResult.response.message)
-            .isEqualTo(BotMessage.SelectCategory(BigDecimal("500"), "такси"))
+            .isEqualTo(BotMessage.SelectCategory(Money.of(BigDecimal("500.00")), "такси"))
         assertThat(parsedExpenseResult.nextState)
-            .isEqualTo(UserState.AwaitingCategorySelection(ParsedExpense(BigDecimal("500"), "такси")))
+            .isEqualTo(UserState.AwaitingCategorySelection(ParsedExpense(Money.of(BigDecimal("500.00")), "такси")))
 
         val savedExpenseResult =
             dialogueRouter.process(
@@ -81,13 +82,13 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
             )
 
         assertThat(savedExpenseResult.response.message)
-            .isEqualTo(BotMessage.ExpenseSaved(BigDecimal("500.00"), category.name, "такси"))
+            .isEqualTo(BotMessage.ExpenseSaved(Money.of(BigDecimal("500.00")), category.name, "такси"))
         assertThat(savedExpenseResult.nextState).isEqualTo(UserState.Idle)
 
         val expenses = findExpenses(userId)
 
         assertThat(expenses).hasSize(1)
-        assertThat(expenses.single().amount).isEqualByComparingTo(BigDecimal("500"))
+        assertThat(expenses.single().amount).isEqualTo(Money.of(BigDecimal("500.00")))
         assertThat(expenses.single().categoryId).isEqualTo(category.id)
         assertThat(expenses.single().description).isEqualTo("такси")
     }
@@ -224,10 +225,10 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
             )
         val categorySelectionAction = result.response.actions.single() as BotAction.ShowCategorySelection
 
-        assertThat(result.response.message).isEqualTo(BotMessage.SelectCategory(BigDecimal("500"), "такси"))
+        assertThat(result.response.message).isEqualTo(BotMessage.SelectCategory(Money.of(BigDecimal("500.00")), "такси"))
         assertThat(categorySelectionAction.categories).isNotEmpty()
 
-        return ParsedExpense(BigDecimal("500"), "такси")
+        return ParsedExpense(Money.of(BigDecimal("500.00")), "такси")
     }
 
     private fun userInput(

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
@@ -11,6 +11,7 @@ import me.kmozze.expensetracker.handler.statehandler.StateHandler
 import me.kmozze.expensetracker.model.domain.BotMessage
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.ParsedExpense
 import me.kmozze.expensetracker.model.domain.UserInput
 import me.kmozze.expensetracker.model.domain.UserState
@@ -34,11 +35,11 @@ class RoutingHandlerTest {
         val idleHandler = RecordingStateHandler(UserState.Idle::class)
         val firstState =
             UserState.AwaitingCategorySelection(
-                ParsedExpense(BigDecimal("500"), "такси"),
+                ParsedExpense(Money.of(BigDecimal("500")), "такси"),
             )
         val secondState =
             UserState.AwaitingCategorySelection(
-                ParsedExpense(BigDecimal("750"), "обед"),
+                ParsedExpense(Money.of(BigDecimal("750")), "обед"),
             )
 
         val router =

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/model/domain/MoneyTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/model/domain/MoneyTest.kt
@@ -1,0 +1,29 @@
+package me.kmozze.expensetracker.unit.model.domain
+
+import me.kmozze.expensetracker.model.domain.Money
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class MoneyTest {
+    @Test
+    fun `create money with two fraction digits`() {
+        val money = Money.of(BigDecimal("500"))
+
+        assertThat(money.value).isEqualTo(BigDecimal("500.00"))
+    }
+
+    @Test
+    fun `round money half up`() {
+        val money = Money.of(BigDecimal("10.555"))
+
+        assertThat(money.value).isEqualTo(BigDecimal("10.56"))
+    }
+
+    @Test
+    fun `format money as plain decimal`() {
+        val money = Money.of(BigDecimal("10.5"))
+
+        assertThat(money.format()).isEqualTo("10.50")
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/service/parser/InputExpenseParsingServiceTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/service/parser/InputExpenseParsingServiceTest.kt
@@ -2,6 +2,7 @@ package me.kmozze.expensetracker.unit.service.parser
 
 import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.exception.BusinessException
+import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.service.parser.InputExpenseParsingService
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.assertThrows
@@ -24,7 +25,7 @@ class InputExpenseParsingServiceTest {
         val result = service.parse(input)
 
         Assertions.assertThat(result.description).isEqualTo(expectedDescription)
-        Assertions.assertThat(result.amount).isEqualByComparingTo(expectedAmount)
+        Assertions.assertThat(result.amount).isEqualTo(Money.of(expectedAmount))
     }
 
     @ParameterizedTest(name = "input: \"{0}\"")
@@ -55,9 +56,11 @@ class InputExpenseParsingServiceTest {
             Stream.of(
                 Arguments.arguments("150.50 Кофе", "Кофе", BigDecimal("150.50")),
                 Arguments.arguments("10,50 Milk", "Milk", BigDecimal("10.50")),
-                Arguments.arguments("Lunch 500", "Lunch", BigDecimal("500")),
-                Arguments.arguments("  Taxi   400  ", "Taxi", BigDecimal("400")),
-                Arguments.arguments("Dinner at restaurant 2500", "Dinner at restaurant", BigDecimal("2500")),
+                Arguments.arguments("Lunch 500", "Lunch", BigDecimal("500.00")),
+                Arguments.arguments("  Taxi   400  ", "Taxi", BigDecimal("400.00")),
+                Arguments.arguments("Dinner at restaurant 2500", "Dinner at restaurant", BigDecimal("2500.00")),
+                Arguments.arguments("Coffee 10.555", "Coffee", BigDecimal("10.56")),
+                Arguments.arguments("Snack 10.554", "Snack", BigDecimal("10.55")),
             )
 
         @JvmStatic
@@ -75,6 +78,7 @@ class InputExpenseParsingServiceTest {
         fun invalidAmountInputs(): Stream<String> =
             Stream.of(
                 "Coffee 0",
+                "Coffee 0.004",
                 "-10 Taxi",
                 "Gym -5.50",
                 "0.00 Gift",


### PR DESCRIPTION
## Что сделано

- Добавлен `Money` value object для денежных значений с единой нормализацией до 2 знаков после запятой и округлением `HALF_UP`.
- `ParsedExpense`, `BotMessage` и `Expense` теперь несут `Money`, а не сырой `BigDecimal`.
- Граница с БД оставлена в `JooqExpenseRepository`: из jOOQ `BigDecimal` конвертируется в `Money`, а при записи обратно используется `expense.amount.value`.
- `InputExpenseParsingService` нормализует сумму сразу после парсинга и валидирует уже нормализованное значение.
- `MessageFormatter` выводит суммы через `Money.format()`, чтобы UI стабильно показывал `500.00 ₽`, а не `500 ₽`.
- Обновлены flow/unit-тесты и добавлены тесты для `Money`.

## Как проверялось

- `./gradlew ktlintCheck`
- `git diff --check`
- `./gradlew test --rerun-tasks --tests "me.kmozze.expensetracker.unit.*" --tests "me.kmozze.expensetracker.integration.handler.AddExpenseFlowTest"`

Ручной сценарий для ревью: добавить расход вроде `500 такси` и проверить, что сумма в выборе категории и в сообщении об успешном сохранении отображается как `500.00 ₽`.

## Ревьюеры

- Danil Mozzhevilov (`Dmozze`)
