### PR TITLE
refactor: simplify StateHandler contract

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/handler/StartCommandHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/StartCommandHandler.kt
@@ -13,10 +13,10 @@ import org.springframework.stereotype.Component
 @Component
 class StartCommandHandler(
     private val categoryService: CategoryService,
-) : UserInputHandler {
+) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    override fun handle(input: UserInput): HandlerResult {
+    fun handle(input: UserInput): HandlerResult {
         val userId = input.userId
         logger.info("Initializing start sequence for user {}", userId)
 

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/UnknownCommandHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/UnknownCommandHandler.kt
@@ -7,8 +7,8 @@ import me.kmozze.expensetracker.model.domain.UserInput
 import org.springframework.stereotype.Component
 
 @Component
-class UnknownCommandHandler : UserInputHandler {
-    override fun handle(input: UserInput): HandlerResult =
+class UnknownCommandHandler {
+    fun handle(input: UserInput): HandlerResult =
         HandlerResult(
             response =
                 HandlerResponse(

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/UserInputHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/UserInputHandler.kt
@@ -1,8 +1,0 @@
-package me.kmozze.expensetracker.handler
-
-import me.kmozze.expensetracker.model.domain.HandlerResult
-import me.kmozze.expensetracker.model.domain.UserInput
-
-interface UserInputHandler {
-    fun handle(input: UserInput): HandlerResult
-}

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseInputHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseInputHandler.kt
@@ -20,7 +20,14 @@ class AwaitingExpenseInputHandler(
 ) : StateHandler {
     override val supportedStateClass: KClass<out UserState> = UserState.AwaitingExpenseInput::class
 
-    override fun handle(input: UserInput): HandlerResult {
+    override fun handle(
+        input: UserInput,
+        currentState: UserState,
+    ): HandlerResult {
+        require(currentState is UserState.AwaitingExpenseInput) {
+            "AwaitingExpenseInputHandler requires AwaitingExpenseInput state"
+        }
+
         val text =
             when (val command = input.command) {
                 UserCommand.AddExpense -> return repeatExpenseInstructions()

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/IdleStateHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/IdleStateHandler.kt
@@ -14,8 +14,15 @@ import kotlin.reflect.KClass
 class IdleStateHandler : StateHandler {
     override val supportedStateClass: KClass<out UserState> = UserState.Idle::class
 
-    override fun handle(input: UserInput): HandlerResult =
-        when (input.command) {
+    override fun handle(
+        input: UserInput,
+        currentState: UserState,
+    ): HandlerResult {
+        require(currentState == UserState.Idle) {
+            "IdleStateHandler requires Idle state"
+        }
+
+        return when (input.command) {
             UserCommand.AddExpense ->
                 HandlerResult(
                     response =
@@ -49,4 +56,5 @@ class IdleStateHandler : StateHandler {
                     nextState = UserState.Idle,
                 )
         }
+    }
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/StateHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/StateHandler.kt
@@ -1,19 +1,15 @@
 package me.kmozze.expensetracker.handler.statehandler
 
-import me.kmozze.expensetracker.handler.UserInputHandler
 import me.kmozze.expensetracker.model.domain.HandlerResult
 import me.kmozze.expensetracker.model.domain.UserInput
 import me.kmozze.expensetracker.model.domain.UserState
 import kotlin.reflect.KClass
 
-interface StateHandler : UserInputHandler {
+interface StateHandler {
     val supportedStateClass: KClass<out UserState>
-
-    override fun handle(input: UserInput): HandlerResult =
-        throw IllegalStateException("${this::class.simpleName} requires current user state")
 
     fun handle(
         input: UserInput,
         currentState: UserState,
-    ): HandlerResult = handle(input)
+    ): HandlerResult
 }


### PR DESCRIPTION
## Что сделано

- Упрощен контракт `StateHandler`: state-handler'ы больше не наследуются от общего `UserInputHandler` и всегда обрабатывают вход через `handle(input, currentState)`.
- `IdleStateHandler` и `AwaitingExpenseInputHandler` переведены на явный state-aware контракт с guard-проверкой ожидаемого состояния.
- Удален лишний `UserInputHandler`; `StartCommandHandler` и `UnknownCommandHandler` остались обычными concrete handlers без искусственного общего интерфейса.

## Как проверить

Автоматические проверки пройдены. Ручное тестирование не проводилось: пользовательское поведение не менялось, PR чистит внутренний handler-контракт.

## Ревьюеры

- Danil Mozzhevilov (`Dmozze`)
