### PR TITLE
fix: stabilize expense period query

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,18 @@ tasks.withType<Test> {
     }
 }
 
+val prepareJooqDdl by tasks.registering(Copy::class) {
+    from("src/main/resources/db/changelog/changesets") {
+        include("*.sql")
+        exclude("002-triggers.sql")
+    }
+    into(layout.buildDirectory.dir("generated-resources/jooq-ddl"))
+}
+
+tasks.named("jooqCodegen") {
+    dependsOn(prepareJooqDdl)
+}
+
 jooq {
     configuration {
         generator {
@@ -84,7 +96,7 @@ jooq {
                 properties {
                     property {
                         key = "scripts"
-                        value = "src/main/resources/db/changelog/changesets/001-init-schema.sql"
+                        value = "build/generated-resources/jooq-ddl/*.sql"
                     }
                     property {
                         key = "sort"

--- a/src/main/kotlin/me/kmozze/expensetracker/repository/IExpenseRepository.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/repository/IExpenseRepository.kt
@@ -13,6 +13,9 @@ interface IExpenseRepository {
 
     fun findById(id: UUID): Expense?
 
+    /**
+     * Returns expenses from newest to oldest, including `from` and excluding `to`.
+     */
     fun findAllByUserIdAndPeriod(
         userId: Long,
         from: OffsetDateTime,

--- a/src/main/kotlin/me/kmozze/expensetracker/repository/JooqExpenseRepository.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/repository/JooqExpenseRepository.kt
@@ -73,6 +73,7 @@ class JooqExpenseRepository(
             .where(EXPENSE.USER_ID.eq(userId))
             .and(EXPENSE.CREATED_AT.ge(from))
             .and(EXPENSE.CREATED_AT.lt(to))
+            .orderBy(EXPENSE.CREATED_AT.desc(), EXPENSE.ID.desc())
             .fetch()
             .map { it.toDomain() }
 

--- a/src/main/resources/db/changelog/changesets/003-expense-period-index.sql
+++ b/src/main/resources/db/changelog/changesets/003-expense-period-index.sql
@@ -2,5 +2,5 @@
 
 -- changeset kmozze:7
 -- comment: replace user expense index with period query index
-DROP INDEX idx_expense_user_id;
-CREATE INDEX idx_expense_user_id_created_at ON expense(user_id, created_at DESC);
+DROP INDEX IF EXISTS idx_expense_user_id;
+CREATE INDEX idx_expense_user_id_created_at ON expense(user_id, created_at);

--- a/src/main/resources/db/changelog/changesets/003-expense-period-index.sql
+++ b/src/main/resources/db/changelog/changesets/003-expense-period-index.sql
@@ -1,0 +1,6 @@
+-- liquibase formatted sql
+
+-- changeset kmozze:7
+-- comment: replace user expense index with period query index
+DROP INDEX idx_expense_user_id;
+CREATE INDEX idx_expense_user_id_created_at ON expense(user_id, created_at DESC);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,3 +3,5 @@ databaseChangeLog:
       file: db/changelog/changesets/001-init-schema.sql
   - include:
       file: db/changelog/changesets/002-triggers.sql
+  - include:
+      file: db/changelog/changesets/003-expense-period-index.sql

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/repository/ExpenseRepositoryTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/repository/ExpenseRepositoryTest.kt
@@ -1,0 +1,95 @@
+package me.kmozze.expensetracker.integration.repository
+
+import me.kmozze.expense.tracker.jooq.tables.references.EXPENSE
+import me.kmozze.expensetracker.integration.AbstractIntegrationTest
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.repository.ICategoryRepository
+import me.kmozze.expensetracker.repository.IExpenseRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.jooq.DSLContext
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@Transactional
+class ExpenseRepositoryTest : AbstractIntegrationTest() {
+    @Autowired
+    private lateinit var categoryRepository: ICategoryRepository
+
+    @Autowired
+    private lateinit var expenseRepository: IExpenseRepository
+
+    @Autowired
+    private lateinit var dsl: DSLContext
+
+    @Test
+    fun `find all by user id and period returns expenses from newest to oldest`() {
+        val userId = 40001L
+        val category =
+            categoryRepository.create(
+                Category(
+                    name = "Еда",
+                    userId = userId,
+                ),
+            )
+        val oldest =
+            createExpense(
+                userId = userId,
+                categoryId = category.id,
+                amount = "100.00",
+                createdAt = OffsetDateTime.parse("2026-05-20T10:00:00Z"),
+            )
+        val newest =
+            createExpense(
+                userId = userId,
+                categoryId = category.id,
+                amount = "300.00",
+                createdAt = OffsetDateTime.parse("2026-05-20T12:00:00Z"),
+            )
+        val middle =
+            createExpense(
+                userId = userId,
+                categoryId = category.id,
+                amount = "200.00",
+                createdAt = OffsetDateTime.parse("2026-05-20T11:00:00Z"),
+            )
+
+        val result =
+            expenseRepository.findAllByUserIdAndPeriod(
+                userId = userId,
+                from = OffsetDateTime.parse("2026-05-20T00:00:00Z"),
+                to = OffsetDateTime.parse("2026-05-21T00:00:00Z"),
+            )
+
+        assertThat(result.map { it.id }).containsExactly(newest.id, middle.id, oldest.id)
+    }
+
+    private fun createExpense(
+        userId: Long,
+        categoryId: UUID,
+        amount: String,
+        createdAt: OffsetDateTime,
+    ): Expense {
+        val expense =
+            expenseRepository.create(
+                Expense(
+                    categoryId = categoryId,
+                    amount = Money.of(BigDecimal(amount)),
+                    userId = userId,
+                ),
+            )
+
+        dsl
+            .update(EXPENSE)
+            .set(EXPENSE.CREATED_AT, createdAt)
+            .where(EXPENSE.ID.eq(expense.id))
+            .execute()
+
+        return expense.copy(createdAt = createdAt)
+    }
+}


### PR DESCRIPTION
## Что сделано

- Закреплена сортировка расходов за период от новых к старым (замечание из review-2026-05-19 #3; повторялось в PR #23: findAllByUserIdAndPeriod без ORDER BY).
- Добавлен Liquibase changeset с композитным индексом для period query (замечание из review-2026-05-19 #3; повторялось в PR #23: индекс (user_id, created_at)).
- Обновлена настройка jOOQ codegen для новых DDL changeset'ов.
- Добавлен integration test на порядок расходов.

## Как проверить

Автоматические проверки пройдены. Ручное тестирование не проводилось, потому что пользовательское поведение не менялось.