### PR TITLE
Add adapter input contract tests

### DIFF
--- a/src/test/kotlin/me/kmozze/expensetracker/integration/handler/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/handler/AddExpenseFlowTest.kt
@@ -9,6 +9,7 @@ import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotMessage
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.ParsedExpense
+import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
 import me.kmozze.expensetracker.model.entity.Category
 import me.kmozze.expensetracker.model.entity.Expense
@@ -146,7 +147,7 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
     }
 
     @Test
-    fun `invalid category callback keeps category selection open without saving expense`() {
+    fun `invalid category selection command keeps category selection open without saving expense`() {
         val userId = 2003L
         val chatId = 3003L
 
@@ -156,7 +157,7 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
             dialogueRouter.processUserInput(
                 userId = userId,
                 chatId = chatId,
-                callbackData = "select_category:not-a-uuid",
+                command = UserCommand.InvalidCategorySelection,
             )
 
         assertThat(result.response.message).isEqualTo(BotMessage.Error(BusinessErrorCode.INVALID_CATEGORY_SELECTION))

--- a/src/test/kotlin/me/kmozze/expensetracker/support/UserInputTestSupport.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/support/UserInputTestSupport.kt
@@ -3,6 +3,7 @@ package me.kmozze.expensetracker.support
 import me.kmozze.expensetracker.adapter.input.UserCommandParser
 import me.kmozze.expensetracker.handler.DialogueRouter
 import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserInput
 
 fun makeUserInput(
@@ -10,13 +11,14 @@ fun makeUserInput(
     chatId: Long,
     text: String? = null,
     callbackData: String? = null,
+    command: UserCommand = UserCommandParser.parse(text = text, callbackData = callbackData),
 ): UserInput =
     UserInput(
         userId = userId,
         chatId = chatId,
         text = text,
         callbackData = callbackData,
-        command = UserCommandParser.parse(text = text, callbackData = callbackData),
+        command = command,
     )
 
 fun DialogueRouter.processUserInput(
@@ -24,4 +26,14 @@ fun DialogueRouter.processUserInput(
     chatId: Long,
     text: String? = null,
     callbackData: String? = null,
-): HandlerResult = process(makeUserInput(userId = userId, chatId = chatId, text = text, callbackData = callbackData))
+    command: UserCommand = UserCommandParser.parse(text = text, callbackData = callbackData),
+): HandlerResult =
+    process(
+        makeUserInput(
+            userId = userId,
+            chatId = chatId,
+            text = text,
+            callbackData = callbackData,
+            command = command,
+        ),
+    )

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/input/CallbackDataParserTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/input/CallbackDataParserTest.kt
@@ -1,0 +1,65 @@
+package me.kmozze.expensetracker.unit.adapter.input
+
+import me.kmozze.expensetracker.adapter.callback.CallbackData
+import me.kmozze.expensetracker.adapter.input.CallbackDataParser
+import me.kmozze.expensetracker.model.domain.UserCommand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.UUID
+import java.util.stream.Stream
+
+class CallbackDataParserTest {
+    @Test
+    fun `parse cancel callback`() {
+        val command = CallbackDataParser.parse(CallbackData.cancel())
+
+        assertThat(command).isEqualTo(UserCommand.Cancel)
+    }
+
+    @Test
+    fun `parse valid category selection callback`() {
+        val command = CallbackDataParser.parse(CallbackData.selectCategory(CATEGORY_ID))
+
+        assertThat(command).isEqualTo(UserCommand.SelectCategory(CATEGORY_ID))
+    }
+
+    @ParameterizedTest(name = "callbackData: \"{0}\"")
+    @MethodSource("invalidCategoryCallbacks")
+    fun `parse invalid category selection callback`(callbackData: String) {
+        val command = CallbackDataParser.parse(callbackData)
+
+        assertThat(command).isEqualTo(UserCommand.InvalidCategorySelection)
+    }
+
+    @ParameterizedTest(name = "callbackData: \"{0}\"")
+    @MethodSource("unsupportedCallbacks")
+    fun `parse unsupported callback`(callbackData: String?) {
+        val command = CallbackDataParser.parse(callbackData)
+
+        assertThat(command).isEqualTo(UserCommand.Unsupported)
+    }
+
+    private companion object {
+        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+
+        @JvmStatic
+        fun invalidCategoryCallbacks(): Stream<String> =
+            Stream.of(
+                "select_category:",
+                "select_category:not-a-uuid",
+                "select_category:00000000-0000-0000-0000-00000000000x",
+            )
+
+        @JvmStatic
+        fun unsupportedCallbacks(): Stream<String?> =
+            Stream.of(
+                null,
+                "",
+                "unknown",
+                "select-category:$CATEGORY_ID",
+                "cancel:extra",
+            )
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/input/UserCommandParserTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/input/UserCommandParserTest.kt
@@ -1,0 +1,68 @@
+package me.kmozze.expensetracker.unit.adapter.input
+
+import me.kmozze.expensetracker.adapter.callback.CallbackData
+import me.kmozze.expensetracker.adapter.input.UserCommandParser
+import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.model.domain.UserCommand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.UUID
+import java.util.stream.Stream
+
+class UserCommandParserTest {
+    @ParameterizedTest(name = "text: \"{0}\"")
+    @MethodSource("textCommands")
+    fun `parse text commands`(
+        text: String,
+        expectedCommand: UserCommand,
+    ) {
+        val command = UserCommandParser.parse(text = text, callbackData = null)
+
+        assertThat(command).isEqualTo(expectedCommand)
+    }
+
+    @Test
+    fun `parse plain text as plain text command`() {
+        val command = UserCommandParser.parse(text = "500 такси", callbackData = null)
+
+        assertThat(command).isEqualTo(UserCommand.PlainText("500 такси"))
+    }
+
+    @Test
+    fun `return unsupported when text and callback data are missing`() {
+        val command = UserCommandParser.parse(text = null, callbackData = null)
+
+        assertThat(command).isEqualTo(UserCommand.Unsupported)
+    }
+
+    @Test
+    fun `parse callback data before text`() {
+        val command =
+            UserCommandParser.parse(
+                text = Buttons.ADD_EXPENSE,
+                callbackData = CallbackData.cancel(),
+            )
+
+        assertThat(command).isEqualTo(UserCommand.Cancel)
+    }
+
+    private companion object {
+        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val SELECT_CATEGORY_CALLBACK: String = CallbackData.selectCategory(CATEGORY_ID)
+
+        @JvmStatic
+        fun textCommands(): Stream<Arguments> =
+            Stream.of(
+                Arguments.arguments("/start", UserCommand.Start),
+                Arguments.arguments("/START", UserCommand.Start),
+                Arguments.arguments(Buttons.ADD_EXPENSE, UserCommand.AddExpense),
+                Arguments.arguments(Buttons.VIEW_EXPENSES, UserCommand.ViewExpenses),
+                Arguments.arguments(Buttons.CATEGORIES, UserCommand.Categories),
+                Arguments.arguments(Buttons.STATISTICS, UserCommand.Statistics),
+                Arguments.arguments(SELECT_CATEGORY_CALLBACK, UserCommand.PlainText(SELECT_CATEGORY_CALLBACK)),
+            )
+    }
+}


### PR DESCRIPTION
## Что сделано

- Добавлены unit-тесты для UserCommandParser: /start, кнопки меню, plain text, пустой input и приоритет callbackData над text.
- Добавлены unit-тесты для CallbackDataParser: cancel, valid/invalid select_category и unknown callback; закреплен текущий контракт invalid callback parsing (контекст замечания из PR #20).
- Flow-тест invalid category selection больше не проверяет malformed callback string напрямую: parser contract закреплен unit-тестом, flow проверяет реакцию на UserCommand.InvalidCategorySelection.
- Test helper позволяет явно передать command, сохраняя прежнее поведение по умолчанию.

## Как проверить

- Автоматические проверки пройдены.

## Ревьюеры

- Danil Mozzhevilov (`Dmozze`)