### PR TITLE
Strengthen service unit tests

### DIFF
--- a/src/test/kotlin/me/kmozze/expensetracker/unit/service/CategoryServiceTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/service/CategoryServiceTest.kt
@@ -1,5 +1,6 @@
 package me.kmozze.expensetracker.unit.service
 
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
@@ -12,6 +13,7 @@ import me.kmozze.expensetracker.service.CategoryService
 import org.jooq.exception.DataAccessException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -21,7 +23,7 @@ import java.util.UUID
 
 @ExtendWith(MockKExtension::class)
 class CategoryServiceTest {
-    private val categoryRepository: ICategoryRepository = mockk(relaxed = true)
+    private val categoryRepository: ICategoryRepository = mockk()
     private lateinit var service: CategoryService
 
     @BeforeEach
@@ -36,24 +38,32 @@ class CategoryServiceTest {
         val result = service.initDefaultCategories(123L)
 
         assertFalse(result, "Должен вернуть false при повторной инициализации")
+        verify(exactly = 1) { categoryRepository.existsByUserId(123L) }
         verify(exactly = 0) { categoryRepository.createIfAbsent(any()) }
+        confirmVerified(categoryRepository)
     }
 
     @Test
     fun `create 5 default categories`() {
+        val createdCategories = mutableListOf<Category>()
         every { categoryRepository.existsByUserId(123L) } returns false
-        every { categoryRepository.createIfAbsent(any()) } returns true
+        every { categoryRepository.createIfAbsent(capture(createdCategories)) } returns true
 
         val result = service.initDefaultCategories(123L)
 
         assertTrue(result, "Должен вернуть true при первом запуске")
+        assertEquals(listOf("Еда", "Транспорт", "Жильё", "Развлечения", "Прочее"), createdCategories.map { it.name })
+        assertTrue(createdCategories.all { it.userId == 123L })
+        verify(exactly = 1) { categoryRepository.existsByUserId(123L) }
         verify(exactly = 5) { categoryRepository.createIfAbsent(any()) }
+        confirmVerified(categoryRepository)
     }
 
     @Test
-    fun `wrap DataAccessException into SystemException`() {
+    fun `init default categories wraps DataAccessException into SystemException`() {
+        val cause = DataAccessException("DB connection failed")
         every { categoryRepository.existsByUserId(123L) } returns false
-        every { categoryRepository.createIfAbsent(any()) } throws DataAccessException("DB connection failed")
+        every { categoryRepository.createIfAbsent(any()) } throws cause
 
         val exception =
             assertThrows<SystemException> {
@@ -61,6 +71,44 @@ class CategoryServiceTest {
             }
 
         assertEquals(SystemErrorCode.DATABASE_ERROR, exception.errorCode)
+        assertEquals(cause, exception.cause)
+        verify(exactly = 1) { categoryRepository.existsByUserId(123L) }
+        verify(exactly = 1) { categoryRepository.createIfAbsent(any()) }
+        confirmVerified(categoryRepository)
+    }
+
+    @Test
+    fun `get categories returns categories for user`() {
+        val userId = 123L
+        val categories =
+            listOf(
+                Category(name = "Еда", userId = userId),
+                Category(name = "Транспорт", userId = userId),
+            )
+        every { categoryRepository.findAllByUserId(userId) } returns categories
+
+        val result = service.getCategories(userId)
+
+        assertEquals(categories, result)
+        verify(exactly = 1) { categoryRepository.findAllByUserId(userId) }
+        confirmVerified(categoryRepository)
+    }
+
+    @Test
+    fun `get categories wraps DataAccessException into SystemException`() {
+        val userId = 123L
+        val cause = DataAccessException("DB connection failed")
+        every { categoryRepository.findAllByUserId(userId) } throws cause
+
+        val exception =
+            assertThrows<SystemException> {
+                service.getCategories(userId)
+            }
+
+        assertEquals(SystemErrorCode.DATABASE_ERROR, exception.errorCode)
+        assertEquals(cause, exception.cause)
+        verify(exactly = 1) { categoryRepository.findAllByUserId(userId) }
+        confirmVerified(categoryRepository)
     }
 
     @Test
@@ -79,6 +127,7 @@ class CategoryServiceTest {
 
         assertEquals(category, result)
         verify(exactly = 1) { categoryRepository.findByIdForUser(categoryId, userId) }
+        confirmVerified(categoryRepository)
     }
 
     @Test
@@ -89,7 +138,9 @@ class CategoryServiceTest {
 
         val result = service.findCategoryForUser(categoryId, userId)
 
-        assertEquals(null, result)
+        assertNull(result)
+        verify(exactly = 1) { categoryRepository.findByIdForUser(categoryId, userId) }
+        confirmVerified(categoryRepository)
     }
 
     @Test
@@ -106,5 +157,7 @@ class CategoryServiceTest {
 
         assertEquals(SystemErrorCode.DATABASE_ERROR, exception.errorCode)
         assertEquals(cause, exception.cause)
+        verify(exactly = 1) { categoryRepository.findByIdForUser(categoryId, userId) }
+        confirmVerified(categoryRepository)
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/service/ExpenseServiceTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/service/ExpenseServiceTest.kt
@@ -1,0 +1,118 @@
+package me.kmozze.expensetracker.unit.service
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import me.kmozze.expensetracker.exception.SystemErrorCode
+import me.kmozze.expensetracker.exception.SystemException
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.ParsedExpense
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.repository.IExpenseRepository
+import me.kmozze.expensetracker.service.ExpenseService
+import me.kmozze.expensetracker.service.parser.InputExpenseParsingService
+import org.jooq.exception.DataAccessException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class ExpenseServiceTest {
+    private val expenseTextParser: InputExpenseParsingService = mockk()
+    private val expenseRepository: IExpenseRepository = mockk()
+    private lateinit var service: ExpenseService
+
+    @BeforeEach
+    fun setUp() {
+        service =
+            ExpenseService(
+                expenseTextParser = expenseTextParser,
+                expenseRepository = expenseRepository,
+            )
+    }
+
+    @Test
+    fun `parse expense returns parsed expense from parser`() {
+        val text = "500 такси"
+        val parsedExpense = ParsedExpense(EXPENSE_AMOUNT, "такси")
+        every { expenseTextParser.parse(text) } returns parsedExpense
+
+        val result = service.parseExpense(text)
+
+        assertEquals(parsedExpense, result)
+        verify(exactly = 1) { expenseTextParser.parse(text) }
+        confirmVerified(expenseTextParser, expenseRepository)
+    }
+
+    @Test
+    fun `save expense creates expense from parsed expense`() {
+        val userId = 123L
+        val categoryId = UUID.randomUUID()
+        val parsedExpense = ParsedExpense(EXPENSE_AMOUNT, "такси")
+        val expenseSlot = slot<Expense>()
+        val savedExpenseId = UUID.randomUUID()
+        val savedAt = OffsetDateTime.parse("2026-05-22T10:00:00Z")
+        every { expenseRepository.create(capture(expenseSlot)) } answers {
+            expenseSlot.captured.copy(id = savedExpenseId, createdAt = savedAt)
+        }
+
+        val result =
+            service.saveExpense(
+                userId = userId,
+                categoryId = categoryId,
+                parsedExpense = parsedExpense,
+            )
+
+        val createdExpense = expenseSlot.captured
+        assertEquals(categoryId, createdExpense.categoryId)
+        assertEquals(EXPENSE_AMOUNT, createdExpense.amount)
+        assertEquals(userId, createdExpense.userId)
+        assertEquals("такси", createdExpense.description)
+        assertNull(createdExpense.createdAt)
+
+        assertEquals(savedExpenseId, result.id)
+        assertEquals(categoryId, result.categoryId)
+        assertEquals(EXPENSE_AMOUNT, result.amount)
+        assertEquals(userId, result.userId)
+        assertEquals("такси", result.description)
+        assertEquals(savedAt, result.createdAt)
+        verify(exactly = 1) { expenseRepository.create(any()) }
+        confirmVerified(expenseTextParser, expenseRepository)
+    }
+
+    @Test
+    fun `save expense wraps DataAccessException into SystemException`() {
+        val userId = 123L
+        val categoryId = UUID.randomUUID()
+        val parsedExpense = ParsedExpense(EXPENSE_AMOUNT, "такси")
+        val cause = DataAccessException("DB connection failed")
+        every { expenseRepository.create(any()) } throws cause
+
+        val exception =
+            assertThrows<SystemException> {
+                service.saveExpense(
+                    userId = userId,
+                    categoryId = categoryId,
+                    parsedExpense = parsedExpense,
+                )
+            }
+
+        assertEquals(SystemErrorCode.DATABASE_ERROR, exception.errorCode)
+        assertEquals(cause, exception.cause)
+        verify(exactly = 1) { expenseRepository.create(any()) }
+        confirmVerified(expenseTextParser, expenseRepository)
+    }
+
+    private companion object {
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+    }
+}


### PR DESCRIPTION
## Что сделано

- Убран relaxed mock из CategoryServiceTest: repository calls задаются и проверяются явно через verify/confirmVerified (замечание из PR #10: пункт про relaxed mocks в CategoryServiceTest).
- Усилены тесты CategoryService: проверяются default category names/userId, getCategories success/error path и сохранение cause при wrapping DataAccessException (замечание из PR #10: пункт про cause assertions).
- Добавлен ExpenseServiceTest: parseExpense делегирует в parser, saveExpense маппит ParsedExpense в Expense, wrapping DataAccessException сохраняет cause.

## Как проверить

- Автоматические проверки пройдены.

## Ревьюеры

- Danil Mozzhevilov (`Dmozze`)