### PR TITLE
Add dialogue state handler unit tests

### DIFF
--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
@@ -1,4 +1,4 @@
-package me.kmozze.expensetracker.integration.handler
+package me.kmozze.expensetracker.integration.flow
 
 import me.kmozze.expensetracker.adapter.callback.CallbackData
 import me.kmozze.expensetracker.adapter.ui.Buttons
@@ -10,7 +10,6 @@ import me.kmozze.expensetracker.model.domain.BotMessage
 import me.kmozze.expensetracker.model.domain.HandlerResult
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.ParsedExpense
-import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
 import me.kmozze.expensetracker.model.entity.Category
 import me.kmozze.expensetracker.model.entity.Expense
@@ -110,45 +109,6 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
     }
 
     @Test
-    fun `cancel category selection returns to idle without saving expense`() {
-        val userId = 2002L
-        val chatId = 3002L
-
-        startCategorySelection(userId, chatId)
-
-        val result =
-            dialogueRouter.processUserInput(
-                userId = userId,
-                chatId = chatId,
-                callbackData = CallbackData.cancel(),
-            )
-
-        assertThat(result.response.message).isEqualTo(BotMessage.ExpenseCanceled)
-        assertThat(result.nextState).isEqualTo(UserState.Idle)
-        assertThat(findExpenses(userId)).isEmpty()
-    }
-
-    @Test
-    fun `invalid category selection command keeps category selection open without saving expense`() {
-        val userId = 2003L
-        val chatId = 3003L
-
-        startCategorySelection(userId, chatId)
-
-        val result =
-            dialogueRouter.processUserInput(
-                userId = userId,
-                chatId = chatId,
-                command = UserCommand.InvalidCategorySelection,
-            )
-
-        assertThat(result.response.message).isEqualTo(BotMessage.Error(BusinessErrorCode.INVALID_CATEGORY_SELECTION))
-        assertThat(result.response.actions.single()).isInstanceOf(BotAction.ShowCategorySelection::class.java)
-        assertThat(result.nextState).isEqualTo(UserState.AwaitingCategorySelection(EXPENSE_WITH_DESCRIPTION))
-        assertThat(findExpenses(userId)).isEmpty()
-    }
-
-    @Test
     fun `foreign category callback keeps category selection open without saving expense`() {
         val userId = 2004L
         val chatId = 3004L
@@ -193,26 +153,6 @@ class AddExpenseFlowTest : AbstractIntegrationTest() {
 
         assertThat(result.response.message).isEqualTo(BotMessage.Error(BusinessErrorCode.EXPENSE_INVALID_FORMAT))
         assertThat(result.nextState).isEqualTo(UserState.AwaitingExpenseInput)
-        assertThat(findExpenses(userId)).isEmpty()
-    }
-
-    @Test
-    fun `expense input without categories returns no categories message without saving expense`() {
-        val userId = 2007L
-        val chatId = 3007L
-
-        dialogueRouter.processUserInput(userId = userId, chatId = chatId, text = Buttons.ADD_EXPENSE)
-
-        val result =
-            dialogueRouter.processUserInput(
-                userId = userId,
-                chatId = chatId,
-                text = EXPENSE_TEXT_WITH_DESCRIPTION,
-            )
-
-        assertThat(result.response.message).isEqualTo(BotMessage.NoCategories)
-        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
-        assertThat(result.nextState).isEqualTo(UserState.Idle)
         assertThat(findExpenses(userId)).isEmpty()
     }
 

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/StartFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/StartFlowTest.kt
@@ -1,4 +1,4 @@
-package me.kmozze.expensetracker.integration.handler
+package me.kmozze.expensetracker.integration.flow
 
 import me.kmozze.expensetracker.handler.DialogueRouter
 import me.kmozze.expensetracker.integration.AbstractIntegrationTest
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
 @Transactional
-class StartCommandTest : AbstractIntegrationTest() {
+class StartFlowTest : AbstractIntegrationTest() {
     @Autowired
     private lateinit var dialogueRouter: DialogueRouter
 

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingCategorySelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingCategorySelectionHandlerTest.kt
@@ -1,0 +1,167 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import me.kmozze.expensetracker.exception.BusinessErrorCode
+import me.kmozze.expensetracker.handler.statehandler.AwaitingCategorySelectionHandler
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotMessage
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.ParsedExpense
+import me.kmozze.expensetracker.model.domain.UserCommand
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import me.kmozze.expensetracker.support.makeUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class AwaitingCategorySelectionHandlerTest {
+    private val categoryService: CategoryService = mockk()
+    private val expenseService: ExpenseService = mockk()
+    private lateinit var handler: AwaitingCategorySelectionHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler =
+            AwaitingCategorySelectionHandler(
+                categoryService = categoryService,
+                expenseService = expenseService,
+            )
+    }
+
+    @Test
+    fun `selected category saves expense and returns idle`() {
+        val category = category(id = CATEGORY_ID)
+        val savedExpense = expense(categoryId = CATEGORY_ID)
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns category
+        every {
+            expenseService.saveExpense(
+                userId = USER_ID,
+                categoryId = CATEGORY_ID,
+                parsedExpense = PARSED_EXPENSE,
+            )
+        } returns savedExpense
+
+        val result = handle(UserCommand.SelectCategory(CATEGORY_ID))
+
+        assertThat(result.response.message)
+            .isEqualTo(BotMessage.ExpenseSaved(EXPENSE_AMOUNT, category.name, EXPENSE_DESCRIPTION))
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        verify(exactly = 1) {
+            expenseService.saveExpense(
+                userId = USER_ID,
+                categoryId = CATEGORY_ID,
+                parsedExpense = PARSED_EXPENSE,
+            )
+        }
+        confirmVerified(categoryService, expenseService)
+    }
+
+    @Test
+    fun `missing category keeps category selection open with error`() {
+        val categories = listOf(category(id = CATEGORY_ID), category(id = SECOND_CATEGORY_ID))
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns null
+        every { categoryService.getCategories(USER_ID) } returns categories
+
+        val result = handle(UserCommand.SelectCategory(CATEGORY_ID))
+
+        assertThat(result.response.message).isEqualTo(BotMessage.Error(BusinessErrorCode.CATEGORY_NOT_FOUND))
+        assertThat(result.response.actions).containsExactly(BotAction.ShowCategorySelection(categories))
+        assertThat(result.nextState).isEqualTo(AWAITING_CATEGORY_SELECTION)
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        verify(exactly = 1) { categoryService.getCategories(USER_ID) }
+        confirmVerified(categoryService, expenseService)
+    }
+
+    @Test
+    fun `invalid category selection keeps category selection open with error`() {
+        val categories = listOf(category(id = CATEGORY_ID), category(id = SECOND_CATEGORY_ID))
+        every { categoryService.getCategories(USER_ID) } returns categories
+
+        val result = handle(UserCommand.InvalidCategorySelection)
+
+        assertThat(result.response.message)
+            .isEqualTo(BotMessage.Error(BusinessErrorCode.INVALID_CATEGORY_SELECTION))
+        assertThat(result.response.actions).containsExactly(BotAction.ShowCategorySelection(categories))
+        assertThat(result.nextState).isEqualTo(AWAITING_CATEGORY_SELECTION)
+        verify(exactly = 1) { categoryService.getCategories(USER_ID) }
+        confirmVerified(categoryService, expenseService)
+    }
+
+    @Test
+    fun `cancel returns idle without service calls`() {
+        val result = handle(UserCommand.Cancel)
+
+        assertThat(result.response.message).isEqualTo(BotMessage.ExpenseCanceled)
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        confirmVerified(categoryService, expenseService)
+    }
+
+    @Test
+    fun `non-selection command repeats category selection`() {
+        val categories = listOf(category(id = CATEGORY_ID), category(id = SECOND_CATEGORY_ID))
+        every { categoryService.getCategories(USER_ID) } returns categories
+
+        val result = handle(UserCommand.PlainText("700 кофе"))
+
+        assertThat(result.response.message)
+            .isEqualTo(BotMessage.SelectCategory(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION))
+        assertThat(result.response.actions).containsExactly(BotAction.ShowCategorySelection(categories))
+        assertThat(result.nextState).isEqualTo(AWAITING_CATEGORY_SELECTION)
+        verify(exactly = 1) { categoryService.getCategories(USER_ID) }
+        confirmVerified(categoryService, expenseService)
+    }
+
+    private fun handle(command: UserCommand) =
+        handler.handle(
+            input =
+                makeUserInput(
+                    userId = USER_ID,
+                    chatId = CHAT_ID,
+                    callbackData = "callback",
+                    command = command,
+                ),
+            currentState = AWAITING_CATEGORY_SELECTION,
+        )
+
+    private fun category(id: UUID): Category =
+        Category(
+            id = id,
+            name = "Еда",
+            userId = USER_ID,
+        )
+
+    private fun expense(categoryId: UUID): Expense =
+        Expense(
+            categoryId = categoryId,
+            amount = EXPENSE_AMOUNT,
+            userId = USER_ID,
+            description = EXPENSE_DESCRIPTION,
+        )
+
+    private companion object {
+        const val USER_ID = 123L
+        const val CHAT_ID = 456L
+        const val EXPENSE_DESCRIPTION = "такси"
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        val PARSED_EXPENSE: ParsedExpense = ParsedExpense(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION)
+        val AWAITING_CATEGORY_SELECTION: UserState.AwaitingCategorySelection =
+            UserState.AwaitingCategorySelection(PARSED_EXPENSE)
+        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val SECOND_CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseInputHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseInputHandlerTest.kt
@@ -1,0 +1,147 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import me.kmozze.expensetracker.exception.BusinessErrorCode
+import me.kmozze.expensetracker.exception.exception
+import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseInputHandler
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotMessage
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.ParsedExpense
+import me.kmozze.expensetracker.model.domain.UserCommand
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import me.kmozze.expensetracker.support.makeUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class AwaitingExpenseInputHandlerTest {
+    private val expenseService: ExpenseService = mockk()
+    private val categoryService: CategoryService = mockk()
+    private lateinit var handler: AwaitingExpenseInputHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler =
+            AwaitingExpenseInputHandler(
+                expenseService = expenseService,
+                categoryService = categoryService,
+            )
+    }
+
+    @Test
+    fun `plain text parses expense and opens category selection`() {
+        val categories = listOf(category(id = FIRST_CATEGORY_ID), category(id = SECOND_CATEGORY_ID))
+        every { expenseService.parseExpense(EXPENSE_TEXT) } returns PARSED_EXPENSE
+        every { categoryService.getCategories(USER_ID) } returns categories
+
+        val result = handle(UserCommand.PlainText(EXPENSE_TEXT))
+
+        assertThat(result.response.message)
+            .isEqualTo(BotMessage.SelectCategory(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION))
+        assertThat(result.response.actions).containsExactly(BotAction.ShowCategorySelection(categories))
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingCategorySelection(PARSED_EXPENSE))
+        verify(exactly = 1) { expenseService.parseExpense(EXPENSE_TEXT) }
+        verify(exactly = 1) { categoryService.getCategories(USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `parse error keeps awaiting expense input without loading categories`() {
+        every { expenseService.parseExpense(EXPENSE_TEXT) } throws BusinessErrorCode.EXPENSE_INVALID_FORMAT.exception()
+
+        val result = handle(UserCommand.PlainText(EXPENSE_TEXT))
+
+        assertThat(result.response.message).isEqualTo(BotMessage.Error(BusinessErrorCode.EXPENSE_INVALID_FORMAT))
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingExpenseInput)
+        verify(exactly = 1) { expenseService.parseExpense(EXPENSE_TEXT) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `parsed expense without categories returns no categories message`() {
+        every { expenseService.parseExpense(EXPENSE_TEXT) } returns PARSED_EXPENSE
+        every { categoryService.getCategories(USER_ID) } returns emptyList()
+
+        val result = handle(UserCommand.PlainText(EXPENSE_TEXT))
+
+        assertThat(result.response.message).isEqualTo(BotMessage.NoCategories)
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.parseExpense(EXPENSE_TEXT) }
+        verify(exactly = 1) { categoryService.getCategories(USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `add expense command repeats input instructions without parsing`() {
+        val result = handle(UserCommand.AddExpense)
+
+        assertThat(result.response.message).isEqualTo(BotMessage.AddExpenseInstructions)
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingExpenseInput)
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `menu command leaves expense input with feature in progress`() {
+        val result = handle(UserCommand.ViewExpenses)
+
+        assertThat(result.response.message).isEqualTo(BotMessage.FeatureInProgress)
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `unsupported command repeats input instructions without parsing`() {
+        val result = handle(UserCommand.Unsupported)
+
+        assertThat(result.response.message).isEqualTo(BotMessage.AddExpenseInstructions)
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingExpenseInput)
+        confirmVerified(expenseService, categoryService)
+    }
+
+    private fun handle(command: UserCommand) =
+        handler.handle(
+            input =
+                makeUserInput(
+                    userId = USER_ID,
+                    chatId = CHAT_ID,
+                    text = EXPENSE_TEXT,
+                    command = command,
+                ),
+            currentState = UserState.AwaitingExpenseInput,
+        )
+
+    private fun category(id: UUID): Category =
+        Category(
+            id = id,
+            name = "Еда",
+            userId = USER_ID,
+        )
+
+    private companion object {
+        const val USER_ID = 123L
+        const val CHAT_ID = 456L
+        const val EXPENSE_TEXT = "500 такси"
+        const val EXPENSE_DESCRIPTION = "такси"
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        val PARSED_EXPENSE: ParsedExpense = ParsedExpense(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION)
+        val FIRST_CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val SECOND_CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/IdleStateHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/IdleStateHandlerTest.kt
@@ -1,0 +1,89 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import me.kmozze.expensetracker.handler.statehandler.IdleStateHandler
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotMessage
+import me.kmozze.expensetracker.model.domain.UserCommand
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.support.makeUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.UUID
+import java.util.stream.Stream
+
+class IdleStateHandlerTest {
+    private val handler = IdleStateHandler()
+
+    @Test
+    fun `add expense command starts expense input`() {
+        val result =
+            handler.handle(
+                input = makeInput(UserCommand.AddExpense),
+                currentState = UserState.Idle,
+            )
+
+        assertThat(result.response.message).isEqualTo(BotMessage.AddExpenseInstructions)
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingExpenseInput)
+    }
+
+    @ParameterizedTest(name = "command: {0}")
+    @MethodSource("featureInProgressCommands")
+    fun `menu commands return feature in progress`(command: UserCommand) {
+        val result =
+            handler.handle(
+                input = makeInput(command),
+                currentState = UserState.Idle,
+            )
+
+        assertThat(result.response.message).isEqualTo(BotMessage.FeatureInProgress)
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+    }
+
+    @ParameterizedTest(name = "command: {0}")
+    @MethodSource("unsupportedCommands")
+    fun `unsupported commands keep idle state`(command: UserCommand) {
+        val result =
+            handler.handle(
+                input = makeInput(command),
+                currentState = UserState.Idle,
+            )
+
+        assertThat(result.response.message).isEqualTo(BotMessage.UnknownCommand)
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+    }
+
+    private fun makeInput(command: UserCommand) =
+        makeUserInput(
+            userId = USER_ID,
+            chatId = CHAT_ID,
+            command = command,
+        )
+
+    private companion object {
+        const val USER_ID = 123L
+        const val CHAT_ID = 456L
+
+        @JvmStatic
+        fun featureInProgressCommands(): Stream<UserCommand> =
+            Stream.of(
+                UserCommand.ViewExpenses,
+                UserCommand.Categories,
+                UserCommand.Statistics,
+            )
+
+        @JvmStatic
+        fun unsupportedCommands(): Stream<UserCommand> =
+            Stream.of(
+                UserCommand.Unsupported,
+                UserCommand.Cancel,
+                UserCommand.InvalidCategorySelection,
+                UserCommand.PlainText("500 такси"),
+                UserCommand.SelectCategory(UUID.fromString("00000000-0000-0000-0000-000000000001")),
+            )
+    }
+}


### PR DESCRIPTION
## Что сделано

- Добавлены быстрые unit-тесты для IdleStateHandler, AwaitingExpenseInputHandler и AwaitingCategorySelectionHandler.
- Интеграционные сценарии перенесены из integration/handler в integration/flow, StartCommandTest переименован в StartFlowTest.
- AddExpenseFlowTest разгружен от веток, которые теперь покрываются unit-тестами handler'ов; в flow оставлены end-to-end happy paths и критичные негативные сценарии.

## Как проверить

Автоматические проверки пройдены. Ручное тестирование не проводилось, потому что пользовательское поведение не менялось.