### PR TITLE
Make flow integration DB cleanup explicit

### DIFF
--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AbstractFlowIntegrationTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AbstractFlowIntegrationTest.kt
@@ -1,0 +1,31 @@
+package me.kmozze.expensetracker.integration.flow
+
+import me.kmozze.expense.tracker.jooq.tables.references.CATEGORY
+import me.kmozze.expense.tracker.jooq.tables.references.EXPENSE
+import me.kmozze.expensetracker.integration.AbstractIntegrationTest
+import org.jooq.DSLContext
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+
+abstract class AbstractFlowIntegrationTest : AbstractIntegrationTest() {
+    @Autowired
+    private lateinit var dsl: DSLContext
+
+    @BeforeEach
+    fun cleanDatabaseBeforeTest() {
+        truncateFlowTables()
+    }
+
+    @AfterEach
+    fun cleanDatabaseAfterTest() {
+        truncateFlowTables()
+    }
+
+    private fun truncateFlowTables() {
+        dsl
+            .truncate(EXPENSE, CATEGORY)
+            .cascade()
+            .execute()
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
@@ -4,7 +4,6 @@ import me.kmozze.expensetracker.adapter.callback.CallbackData
 import me.kmozze.expensetracker.adapter.ui.Buttons
 import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.handler.DialogueRouter
-import me.kmozze.expensetracker.integration.AbstractIntegrationTest
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotMessage
 import me.kmozze.expensetracker.model.domain.HandlerResult
@@ -19,13 +18,11 @@ import me.kmozze.expensetracker.support.processUserInput
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
 import java.time.OffsetDateTime
 import java.util.UUID
 
-@Transactional
-class AddExpenseFlowTest : AbstractIntegrationTest() {
+class AddExpenseFlowTest : AbstractFlowIntegrationTest() {
     @Autowired
     private lateinit var dialogueRouter: DialogueRouter
 

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/StartFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/StartFlowTest.kt
@@ -1,7 +1,6 @@
 package me.kmozze.expensetracker.integration.flow
 
 import me.kmozze.expensetracker.handler.DialogueRouter
-import me.kmozze.expensetracker.integration.AbstractIntegrationTest
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotMessage
 import me.kmozze.expensetracker.model.domain.UserState
@@ -11,11 +10,9 @@ import me.kmozze.expensetracker.support.processUserInput
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
 
-@Transactional
-class StartFlowTest : AbstractIntegrationTest() {
+class StartFlowTest : AbstractFlowIntegrationTest() {
     @Autowired
     private lateinit var dialogueRouter: DialogueRouter
 

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
@@ -24,7 +24,7 @@ import kotlin.reflect.KClass
 
 class RoutingHandlerTest {
     private val userSessionService = UserSessionService()
-    private val startCommandHandler: StartCommandHandler = mockk(relaxed = true)
+    private val startCommandHandler: StartCommandHandler = mockk()
     private val unknownCommandHandler = UnknownCommandHandler()
     private val errorHandler = ErrorHandler()
 


### PR DESCRIPTION
## Что сделано

- Добавлен flow-only base для явной очистки таблиц expense/category до и после flow-тестов; flow-тесты больше не зависят от @Transactional rollback (замечание из PR #10 про устойчивость integration-тестов к REQUIRES_NEW / async).
- AddExpenseFlowTest и StartFlowTest переведены на новый flow base без изменения проверяемого пользовательского поведения.
- RoutingHandlerTest переведен со relaxed mock на strict mock, чтобы тест ловил неожиданные вызовы (замечание из PR #10 про relaxed mocks).

## Как проверить

Автоматические проверки пройдены. Ручное тестирование не проводилось, потому что пользовательское поведение не менялось.