### PR TITLE
Introduce expense draft

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
@@ -67,12 +67,8 @@ class AwaitingCategorySelectionHandler(
                     errorCode = BusinessErrorCode.CATEGORY_NOT_FOUND,
                 )
 
-        val expense =
-            expenseService.saveExpense(
-                userId = input.userId,
-                categoryId = category.id,
-                parsedExpense = currentState.parsedExpense,
-            )
+        val expenseDraft = currentState.expenseDraft.copy(categoryId = category.id)
+        val expense = expenseService.saveExpense(input.userId, expenseDraft)
 
         return HandlerResult(
             response =
@@ -111,8 +107,8 @@ class AwaitingCategorySelectionHandler(
                 HandlerResponse(
                     message =
                         BotMessage.SelectCategory(
-                            amount = currentState.parsedExpense.amount,
-                            description = currentState.parsedExpense.description,
+                            amount = currentState.expenseDraft.amount,
+                            description = currentState.expenseDraft.description,
                         ),
                     actions = listOf(BotAction.ShowCategorySelection(categories)),
                 ),

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseInputHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseInputHandler.kt
@@ -39,7 +39,7 @@ class AwaitingExpenseInputHandler(
                 else -> return repeatExpenseInstructions()
             }
 
-        val parsedExpense =
+        val expenseDraft =
             try {
                 expenseService.parseExpense(text)
             } catch (e: BusinessException) {
@@ -63,12 +63,12 @@ class AwaitingExpenseInputHandler(
                 HandlerResponse(
                     message =
                         BotMessage.SelectCategory(
-                            amount = parsedExpense.amount,
-                            description = parsedExpense.description,
+                            amount = expenseDraft.amount,
+                            description = expenseDraft.description,
                         ),
                     actions = listOf(BotAction.ShowCategorySelection(categories)),
                 ),
-            nextState = UserState.AwaitingCategorySelection(parsedExpense),
+            nextState = UserState.AwaitingCategorySelection(expenseDraft),
         )
     }
 

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/ExpenseDraft.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/ExpenseDraft.kt
@@ -1,0 +1,16 @@
+package me.kmozze.expensetracker.model.domain
+
+import java.time.LocalDate
+import java.util.UUID
+
+data class ExpenseDraft(
+    val amount: Money,
+    val description: String?,
+    val categoryId: UUID? = null,
+    val expenseDate: LocalDate? = null,
+) {
+    fun requireCategoryId(): UUID =
+        requireNotNull(categoryId) {
+            "ExpenseDraft.categoryId must be set before saving"
+        }
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/ParsedExpense.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/ParsedExpense.kt
@@ -1,6 +1,0 @@
-package me.kmozze.expensetracker.model.domain
-
-data class ParsedExpense(
-    val amount: Money,
-    val description: String?,
-)

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/UserState.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/UserState.kt
@@ -6,6 +6,6 @@ sealed class UserState {
     data object AwaitingExpenseInput : UserState()
 
     data class AwaitingCategorySelection(
-        val parsedExpense: ParsedExpense,
+        val expenseDraft: ExpenseDraft,
     ) : UserState()
 }

--- a/src/main/kotlin/me/kmozze/expensetracker/service/ExpenseService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/ExpenseService.kt
@@ -2,7 +2,7 @@ package me.kmozze.expensetracker.service
 
 import me.kmozze.expensetracker.exception.SystemErrorCode
 import me.kmozze.expensetracker.exception.exception
-import me.kmozze.expensetracker.model.domain.ParsedExpense
+import me.kmozze.expensetracker.model.domain.ExpenseDraft
 import me.kmozze.expensetracker.model.entity.Expense
 import me.kmozze.expensetracker.repository.IExpenseRepository
 import me.kmozze.expensetracker.service.parser.InputExpenseParsingService
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
-import java.util.UUID
 
 @Service
 class ExpenseService(
@@ -20,27 +19,27 @@ class ExpenseService(
 ) {
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    fun parseExpense(text: String): ParsedExpense {
-        val parsedExpense = expenseTextParser.parse(text)
-        logger.info("Expense parsed successfully: {}", parsedExpense)
+    fun parseExpense(text: String): ExpenseDraft {
+        val expenseDraft = expenseTextParser.parse(text)
+        logger.info("Expense parsed successfully: {}", expenseDraft)
 
-        return parsedExpense
+        return expenseDraft
     }
 
     @Transactional
     fun saveExpense(
         userId: Long,
-        categoryId: UUID,
-        parsedExpense: ParsedExpense,
+        expenseDraft: ExpenseDraft,
     ): Expense =
         try {
+            val categoryId = expenseDraft.requireCategoryId()
             val expense =
                 Expense(
                     categoryId = categoryId,
-                    amount = parsedExpense.amount,
+                    amount = expenseDraft.amount,
                     userId = userId,
-                    expenseDate = LocalDate.now(),
-                    description = parsedExpense.description,
+                    expenseDate = expenseDraft.expenseDate ?: LocalDate.now(),
+                    description = expenseDraft.description,
                 )
 
             expenseRepository.create(expense)

--- a/src/main/kotlin/me/kmozze/expensetracker/service/parser/InputExpenseParsingService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/parser/InputExpenseParsingService.kt
@@ -2,14 +2,14 @@ package me.kmozze.expensetracker.service.parser
 
 import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.exception.exception
+import me.kmozze.expensetracker.model.domain.ExpenseDraft
 import me.kmozze.expensetracker.model.domain.Money
-import me.kmozze.expensetracker.model.domain.ParsedExpense
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 
 @Service
 class InputExpenseParsingService {
-    fun parse(text: String): ParsedExpense {
+    fun parse(text: String): ExpenseDraft {
         val words = text.split(Regex("""\s+""")).filter { it.isNotBlank() }
 
         if (words.isEmpty()) throw BusinessErrorCode.EXPENSE_INVALID_FORMAT.exception()
@@ -51,13 +51,13 @@ class InputExpenseParsingService {
     private fun createExpense(
         description: String?,
         amount: BigDecimal,
-    ): ParsedExpense {
+    ): ExpenseDraft {
         val money = Money.of(amount)
 
         if (money.value <= BigDecimal.ZERO) {
             throw BusinessErrorCode.INVALID_AMOUNT.exception()
         }
-        return ParsedExpense(
+        return ExpenseDraft(
             amount = money,
             description = description?.trim()?.takeIf { it.isNotEmpty() },
         )

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
@@ -6,9 +6,9 @@ import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.handler.DialogueRouter
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotMessage
+import me.kmozze.expensetracker.model.domain.ExpenseDraft
 import me.kmozze.expensetracker.model.domain.HandlerResult
 import me.kmozze.expensetracker.model.domain.Money
-import me.kmozze.expensetracker.model.domain.ParsedExpense
 import me.kmozze.expensetracker.model.domain.UserState
 import me.kmozze.expensetracker.model.entity.Category
 import me.kmozze.expensetracker.model.entity.Expense
@@ -244,8 +244,8 @@ class AddExpenseFlowTest : AbstractFlowIntegrationTest() {
         const val EXPENSE_TEXT_WITHOUT_DESCRIPTION = "500"
         const val EXPENSE_DESCRIPTION = "такси"
         val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
-        val EXPENSE_WITH_DESCRIPTION: ParsedExpense = ParsedExpense(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION)
-        val EXPENSE_WITHOUT_DESCRIPTION: ParsedExpense = ParsedExpense(EXPENSE_AMOUNT, null)
+        val EXPENSE_WITH_DESCRIPTION: ExpenseDraft = ExpenseDraft(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION)
+        val EXPENSE_WITHOUT_DESCRIPTION: ExpenseDraft = ExpenseDraft(EXPENSE_AMOUNT, null)
         val TEST_PERIOD_FROM: OffsetDateTime = OffsetDateTime.parse("2000-01-01T00:00:00Z")
         val TEST_PERIOD_TO: OffsetDateTime = OffsetDateTime.parse("2100-01-01T00:00:00Z")
     }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
@@ -8,10 +8,10 @@ import me.kmozze.expensetracker.handler.StartCommandHandler
 import me.kmozze.expensetracker.handler.UnknownCommandHandler
 import me.kmozze.expensetracker.handler.statehandler.StateHandler
 import me.kmozze.expensetracker.model.domain.BotMessage
+import me.kmozze.expensetracker.model.domain.ExpenseDraft
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.HandlerResult
 import me.kmozze.expensetracker.model.domain.Money
-import me.kmozze.expensetracker.model.domain.ParsedExpense
 import me.kmozze.expensetracker.model.domain.UserInput
 import me.kmozze.expensetracker.model.domain.UserState
 import me.kmozze.expensetracker.service.UserSessionService
@@ -35,11 +35,11 @@ class RoutingHandlerTest {
         val idleHandler = RecordingStateHandler(UserState.Idle::class)
         val firstState =
             UserState.AwaitingCategorySelection(
-                ParsedExpense(Money.of(BigDecimal("500")), "такси"),
+                ExpenseDraft(Money.of(BigDecimal("500")), "такси"),
             )
         val secondState =
             UserState.AwaitingCategorySelection(
-                ParsedExpense(Money.of(BigDecimal("750")), "обед"),
+                ExpenseDraft(Money.of(BigDecimal("750")), "обед"),
             )
 
         val router =

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingCategorySelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingCategorySelectionHandlerTest.kt
@@ -9,8 +9,8 @@ import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.handler.statehandler.AwaitingCategorySelectionHandler
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotMessage
+import me.kmozze.expensetracker.model.domain.ExpenseDraft
 import me.kmozze.expensetracker.model.domain.Money
-import me.kmozze.expensetracker.model.domain.ParsedExpense
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
 import me.kmozze.expensetracker.model.entity.Category
@@ -49,8 +49,7 @@ class AwaitingCategorySelectionHandlerTest {
         every {
             expenseService.saveExpense(
                 userId = USER_ID,
-                categoryId = CATEGORY_ID,
-                parsedExpense = PARSED_EXPENSE,
+                expenseDraft = EXPENSE_DRAFT.copy(categoryId = CATEGORY_ID),
             )
         } returns savedExpense
 
@@ -71,8 +70,7 @@ class AwaitingCategorySelectionHandlerTest {
         verify(exactly = 1) {
             expenseService.saveExpense(
                 userId = USER_ID,
-                categoryId = CATEGORY_ID,
-                parsedExpense = PARSED_EXPENSE,
+                expenseDraft = EXPENSE_DRAFT.copy(categoryId = CATEGORY_ID),
             )
         }
         confirmVerified(categoryService, expenseService)
@@ -168,9 +166,9 @@ class AwaitingCategorySelectionHandlerTest {
         const val EXPENSE_DESCRIPTION = "такси"
         val EXPENSE_DATE: LocalDate = LocalDate.parse("2026-05-24")
         val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
-        val PARSED_EXPENSE: ParsedExpense = ParsedExpense(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION)
+        val EXPENSE_DRAFT: ExpenseDraft = ExpenseDraft(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION)
         val AWAITING_CATEGORY_SELECTION: UserState.AwaitingCategorySelection =
-            UserState.AwaitingCategorySelection(PARSED_EXPENSE)
+            UserState.AwaitingCategorySelection(EXPENSE_DRAFT)
         val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
         val SECOND_CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
     }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseInputHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseInputHandlerTest.kt
@@ -10,8 +10,8 @@ import me.kmozze.expensetracker.exception.exception
 import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseInputHandler
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotMessage
+import me.kmozze.expensetracker.model.domain.ExpenseDraft
 import me.kmozze.expensetracker.model.domain.Money
-import me.kmozze.expensetracker.model.domain.ParsedExpense
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
 import me.kmozze.expensetracker.model.entity.Category
@@ -43,7 +43,7 @@ class AwaitingExpenseInputHandlerTest {
     @Test
     fun `plain text parses expense and opens category selection`() {
         val categories = listOf(category(id = FIRST_CATEGORY_ID), category(id = SECOND_CATEGORY_ID))
-        every { expenseService.parseExpense(EXPENSE_TEXT) } returns PARSED_EXPENSE
+        every { expenseService.parseExpense(EXPENSE_TEXT) } returns EXPENSE_DRAFT
         every { categoryService.getCategories(USER_ID) } returns categories
 
         val result = handle(UserCommand.PlainText(EXPENSE_TEXT))
@@ -51,7 +51,7 @@ class AwaitingExpenseInputHandlerTest {
         assertThat(result.response.message)
             .isEqualTo(BotMessage.SelectCategory(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION))
         assertThat(result.response.actions).containsExactly(BotAction.ShowCategorySelection(categories))
-        assertThat(result.nextState).isEqualTo(UserState.AwaitingCategorySelection(PARSED_EXPENSE))
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingCategorySelection(EXPENSE_DRAFT))
         verify(exactly = 1) { expenseService.parseExpense(EXPENSE_TEXT) }
         verify(exactly = 1) { categoryService.getCategories(USER_ID) }
         confirmVerified(expenseService, categoryService)
@@ -72,7 +72,7 @@ class AwaitingExpenseInputHandlerTest {
 
     @Test
     fun `parsed expense without categories returns no categories message`() {
-        every { expenseService.parseExpense(EXPENSE_TEXT) } returns PARSED_EXPENSE
+        every { expenseService.parseExpense(EXPENSE_TEXT) } returns EXPENSE_DRAFT
         every { categoryService.getCategories(USER_ID) } returns emptyList()
 
         val result = handle(UserCommand.PlainText(EXPENSE_TEXT))
@@ -140,7 +140,7 @@ class AwaitingExpenseInputHandlerTest {
         const val EXPENSE_TEXT = "500 такси"
         const val EXPENSE_DESCRIPTION = "такси"
         val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
-        val PARSED_EXPENSE: ParsedExpense = ParsedExpense(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION)
+        val EXPENSE_DRAFT: ExpenseDraft = ExpenseDraft(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION)
         val FIRST_CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
         val SECOND_CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
     }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/service/ExpenseServiceTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/service/ExpenseServiceTest.kt
@@ -8,8 +8,8 @@ import io.mockk.slot
 import io.mockk.verify
 import me.kmozze.expensetracker.exception.SystemErrorCode
 import me.kmozze.expensetracker.exception.SystemException
+import me.kmozze.expensetracker.model.domain.ExpenseDraft
 import me.kmozze.expensetracker.model.domain.Money
-import me.kmozze.expensetracker.model.domain.ParsedExpense
 import me.kmozze.expensetracker.model.entity.Expense
 import me.kmozze.expensetracker.repository.IExpenseRepository
 import me.kmozze.expensetracker.service.ExpenseService
@@ -43,23 +43,23 @@ class ExpenseServiceTest {
     }
 
     @Test
-    fun `parse expense returns parsed expense from parser`() {
+    fun `parse expense returns draft from parser`() {
         val text = "500 такси"
-        val parsedExpense = ParsedExpense(EXPENSE_AMOUNT, "такси")
-        every { expenseTextParser.parse(text) } returns parsedExpense
+        val expenseDraft = ExpenseDraft(EXPENSE_AMOUNT, "такси")
+        every { expenseTextParser.parse(text) } returns expenseDraft
 
         val result = service.parseExpense(text)
 
-        assertEquals(parsedExpense, result)
+        assertEquals(expenseDraft, result)
         verify(exactly = 1) { expenseTextParser.parse(text) }
         confirmVerified(expenseTextParser, expenseRepository)
     }
 
     @Test
-    fun `save expense creates expense from parsed expense`() {
+    fun `save expense creates expense from draft`() {
         val userId = 123L
         val categoryId = UUID.randomUUID()
-        val parsedExpense = ParsedExpense(EXPENSE_AMOUNT, "такси")
+        val expenseDraft = ExpenseDraft(EXPENSE_AMOUNT, "такси", categoryId = categoryId)
         val expenseSlot = slot<Expense>()
         val savedExpenseId = UUID.randomUUID()
         val savedAt = OffsetDateTime.parse("2026-05-22T10:00:00Z")
@@ -71,8 +71,7 @@ class ExpenseServiceTest {
         val result =
             service.saveExpense(
                 userId = userId,
-                categoryId = categoryId,
-                parsedExpense = parsedExpense,
+                expenseDraft = expenseDraft,
             )
         val expenseDateAfterSave = LocalDate.now()
 
@@ -99,7 +98,7 @@ class ExpenseServiceTest {
     fun `save expense wraps DataAccessException into SystemException`() {
         val userId = 123L
         val categoryId = UUID.randomUUID()
-        val parsedExpense = ParsedExpense(EXPENSE_AMOUNT, "такси")
+        val expenseDraft = ExpenseDraft(EXPENSE_AMOUNT, "такси", categoryId = categoryId)
         val cause = DataAccessException("DB connection failed")
         every { expenseRepository.create(any()) } throws cause
 
@@ -107,14 +106,25 @@ class ExpenseServiceTest {
             assertThrows<SystemException> {
                 service.saveExpense(
                     userId = userId,
-                    categoryId = categoryId,
-                    parsedExpense = parsedExpense,
+                    expenseDraft = expenseDraft,
                 )
             }
 
         assertEquals(SystemErrorCode.DATABASE_ERROR, exception.errorCode)
         assertEquals(cause, exception.cause)
         verify(exactly = 1) { expenseRepository.create(any()) }
+        confirmVerified(expenseTextParser, expenseRepository)
+    }
+
+    @Test
+    fun `save expense requires category in draft`() {
+        assertThrows<IllegalArgumentException> {
+            service.saveExpense(
+                userId = 123L,
+                expenseDraft = ExpenseDraft(EXPENSE_AMOUNT, "такси"),
+            )
+        }
+
         confirmVerified(expenseTextParser, expenseRepository)
     }
 


### PR DESCRIPTION
## Что сделано

- `ParsedExpense` заменен на `ExpenseDraft`, чтобы модель ввода расхода могла постепенно дополняться данными между шагами.
- `ExpenseService.saveExpense` теперь принимает собранный draft и проверяет, что категория задана перед сохранением.
- Обновлены handler- и service-тесты под новый контракт без изменения пользовательского сценария.

## Как проверить

Автоматические проверки пройдены. Ручное тестирование проведено.

## Ревьюеры

- Danil Mozzhevilov (`Dmozze`)
