### PR TITLE
Handle stale callbacks in idle state

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/MessageFormatter.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/MessageFormatter.kt
@@ -59,6 +59,9 @@ class MessageFormatter {
             is BotMessage.ExpenseCanceled ->
                 "Добавление расхода отменено."
 
+            is BotMessage.SelectionExpired ->
+                "Этот выбор уже неактуален. Используйте главное меню."
+
             is BotMessage.NoCategories ->
                 "У вас нет ни одной категории. Создайте хотя бы одну, чтобы записывать расходы."
 

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/IdleStateHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/IdleStateHandler.kt
@@ -46,6 +46,21 @@ class IdleStateHandler : StateHandler {
                     nextState = UserState.Idle,
                 )
 
+            UserCommand.Cancel,
+            is UserCommand.SelectCategory,
+            UserCommand.InvalidCategorySelection,
+            is UserCommand.SelectExpenseDate,
+            UserCommand.InvalidExpenseDateSelection,
+            ->
+                HandlerResult(
+                    response =
+                        HandlerResponse(
+                            message = BotMessage.SelectionExpired,
+                            actions = listOf(BotAction.ShowMainMenu),
+                        ),
+                    nextState = UserState.Idle,
+                )
+
             else ->
                 HandlerResult(
                     response =

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/BotMessage.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/BotMessage.kt
@@ -38,6 +38,8 @@ sealed class BotMessage {
 
     data object ExpenseCanceled : BotMessage()
 
+    data object SelectionExpired : BotMessage()
+
     data object NoCategories : BotMessage()
 
     data object FeatureInProgress : BotMessage()

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/IdleStateHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/IdleStateHandlerTest.kt
@@ -58,6 +58,20 @@ class IdleStateHandlerTest {
         assertThat(result.nextState).isEqualTo(UserState.Idle)
     }
 
+    @ParameterizedTest(name = "command: {0}")
+    @MethodSource("staleCallbackCommands")
+    fun `stale callback commands keep idle state with expired selection message`(command: UserCommand) {
+        val result =
+            handler.handle(
+                input = makeInput(command),
+                currentState = UserState.Idle,
+            )
+
+        assertThat(result.response.message).isEqualTo(BotMessage.SelectionExpired)
+        assertThat(result.response.actions).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+    }
+
     private fun makeInput(command: UserCommand) =
         makeUserInput(
             userId = USER_ID,
@@ -81,12 +95,17 @@ class IdleStateHandlerTest {
         fun unsupportedCommands(): Stream<UserCommand> =
             Stream.of(
                 UserCommand.Unsupported,
-                UserCommand.Cancel,
-                UserCommand.InvalidCategorySelection,
-                UserCommand.InvalidExpenseDateSelection,
                 UserCommand.PlainText("500 такси"),
+            )
+
+        @JvmStatic
+        fun staleCallbackCommands(): Stream<UserCommand> =
+            Stream.of(
+                UserCommand.Cancel,
                 UserCommand.SelectCategory(UUID.fromString("00000000-0000-0000-0000-000000000001")),
                 UserCommand.SelectExpenseDate(ExpenseDateSelection.TODAY),
+                UserCommand.InvalidCategorySelection,
+                UserCommand.InvalidExpenseDateSelection,
             )
     }
 }


### PR DESCRIPTION
## Что сделано

- В `Idle` старые inline-кнопки больше не отвечают как неизвестная команда.
- Для устаревшего выбора добавлено отдельное сообщение с возвратом к главному меню.
- Добавлены unit-тесты на stale callback commands в `Idle`.

## Как проверить

Автоматические проверки пройдены. Ручное тестирование проведено.

## Ревьюеры

- Danil Mozzhevilov (`Dmozze`)
