### PR TITLE
Настроить триггеры CI для всех веток

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Gradle checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Generate jOOQ sources
+        run: ./gradlew jooqCodegen
+
+      - name: Check Kotlin style
+        run: ./gradlew ktlintCheck
+
+      - name: Compile Kotlin
+        run: ./gradlew compileKotlin
+
+      - name: Run tests
+        run: ./gradlew test


### PR DESCRIPTION
## Что сделано
- Расширен запуск workflow `.github/workflows/ci.yml` на все события `pull_request` и `push` без привязки только к `main`.
- Оставлен ручной запуск `workflow_dispatch`.
- Это позволит проверять задачи из feature-веток и фичевой разработки до слияния в `main`.

## Пройденные проверки
- Проверены изменённые workflow-файлы локально.
- Изменения зафиксированы в `codex/chore/setup-ci`.