### PR TITLE
test: edit expense flow coverage

### DIFF
--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/EditExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/EditExpenseFlowTest.kt
@@ -1,0 +1,421 @@
+package me.kmozze.expensetracker.integration.flow
+
+import me.kmozze.expensetracker.adapter.callback.CallbackData
+import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.handler.DialogueRouter
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.ResponseDelivery
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.repository.IExpenseRepository
+import me.kmozze.expensetracker.support.processUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
+    @Autowired
+    private lateinit var dialogueRouter: DialogueRouter
+
+    @Autowired
+    private lateinit var expenseRepository: IExpenseRepository
+
+    @Test
+    fun `edit expense from card updates amount category date and description`() {
+        val userId = 2011L
+        val chatId = 3011L
+
+        val createdExpense = createExpense(userId, chatId)
+        val initialCategory = createdExpense.second
+
+        val editStart =
+            requestEdit(userId = userId, chatId = chatId, expenseId = createdExpense.first.id, callbackMessageId = CARD_MESSAGE_ID)
+
+        assertThat(editStart.response.outgoingMessages[0].text).isEqualTo(
+            BotText.ExpenseEditable(
+                amount = createdExpense.first.amount,
+                categoryName = createdExpense.second.name,
+                expenseDate = createdExpense.first.expenseDate,
+                description = createdExpense.first.description,
+            ),
+        )
+        assertThat(editStart.response.outgoingMessages[0].actions).containsExactly(BotAction.ClearInlineKeyboard)
+        assertThat(editStart.response.outgoingMessages[0].delivery).isEqualTo(ResponseDelivery.EditMessage(CARD_MESSAGE_ID))
+        assertThat(editStart.response.outgoingMessages[1].text).isEqualTo(BotText.EditExpenseFieldSelection)
+        assertThat(editStart.response.outgoingMessages[1].actions).containsExactly(BotAction.ShowExpenseEditFieldSelection)
+        assertThat(editStart.nextState).isEqualTo(UserState.AwaitingExpenseEditFieldSelection(createdExpense.first.id))
+
+        val amountPrompt =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = Buttons.EDIT_EXPENSE_AMOUNT,
+            )
+        assertThat(
+            amountPrompt.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.EnterExpenseAmount)
+        assertThat(
+            amountPrompt.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCancel)
+        assertThat(amountPrompt.nextState).isEqualTo(UserState.AwaitingExpenseAmountEdit(expenseId = createdExpense.first.id))
+
+        val amountUpdated =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = "650",
+            )
+        assertThat(amountUpdated.response.outgoingMessages).hasSize(2)
+        assertThat(
+            amountUpdated.response.outgoingMessages
+                .first()
+                .text,
+        ).isEqualTo(BotText.Done)
+        assertThat(
+            amountUpdated.response.outgoingMessages
+                .first()
+                .actions,
+        ).containsExactly(BotAction.RemoveReplyKeyboard)
+        val amountSaved = amountUpdated.savedExpenseMessage()
+        assertThat(amountSaved.amount).isEqualTo(EXPENSE_AMOUNT_UPDATED)
+        assertThat(amountSaved.categoryName).isEqualTo(initialCategory.name)
+        assertThat(amountUpdated.nextState).isEqualTo(UserState.Idle)
+        assertThat(amountUpdated.expenseCardAction().expenseId).isEqualTo(createdExpense.first.id)
+
+        val editAfterAmount =
+            requestEdit(userId = userId, chatId = chatId, expenseId = createdExpense.first.id, callbackMessageId = CARD_MESSAGE_ID)
+        val categorySelectionPrompt =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = Buttons.EDIT_EXPENSE_CATEGORY,
+            )
+        val categorySelection = categorySelectionPrompt.categorySelectionAction()
+        val newCategory = categorySelection.categories.first { it.id != initialCategory.id }
+        val categoryUpdated =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = newCategory.name,
+            )
+        val categorySaved = categoryUpdated.savedExpenseMessage()
+        assertThat(categorySaved.categoryName).isEqualTo(newCategory.name)
+        assertThat(categorySaved.amount).isEqualTo(EXPENSE_AMOUNT_UPDATED)
+        assertThat(categoryUpdated.nextState).isEqualTo(UserState.Idle)
+
+        val editAfterCategory =
+            requestEdit(userId = userId, chatId = chatId, expenseId = createdExpense.first.id, callbackMessageId = CARD_MESSAGE_ID)
+        val dateSelectionPrompt =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = Buttons.EDIT_EXPENSE_DATE,
+            )
+        assertThat(
+            dateSelectionPrompt.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(
+            BotText.SelectExpenseDate(
+                amount = EXPENSE_AMOUNT_UPDATED,
+                categoryName = newCategory.name,
+                description = EXPENSE_DESCRIPTION_UPDATED,
+            ),
+        )
+        assertThat(
+            dateSelectionPrompt.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowExpenseDateSelection)
+        val manualDatePrompt =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = Buttons.ENTER_DATE_MANUALLY,
+            )
+        assertThat(
+            manualDatePrompt.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(
+            BotText.EnterExpenseDateManually(
+                amount = EXPENSE_AMOUNT_UPDATED,
+                categoryName = newCategory.name,
+                description = EXPENSE_DESCRIPTION_UPDATED,
+            ),
+        )
+        assertThat(manualDatePrompt.nextState).isEqualTo(
+            UserState.AwaitingExpenseDateEditManualInput(
+                expenseId = createdExpense.first.id,
+            ),
+        )
+
+        val dateUpdated =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = MANUAL_DATE_TEXT,
+            )
+        val dateSaved = dateUpdated.savedExpenseMessage()
+        assertThat(dateSaved.expenseDate).isEqualTo(MANUAL_DATE)
+        assertThat(dateUpdated.nextState).isEqualTo(UserState.Idle)
+
+        val editAfterDate =
+            requestEdit(userId = userId, chatId = chatId, expenseId = createdExpense.first.id, callbackMessageId = CARD_MESSAGE_ID)
+        val descriptionPrompt =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = Buttons.EDIT_EXPENSE_DESCRIPTION,
+            )
+        assertThat(
+            descriptionPrompt.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.EnterExpenseDescription)
+        assertThat(
+            descriptionPrompt.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCancel)
+
+        val descriptionUpdated =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = DESCRIPTION_UPDATED,
+            )
+        val descriptionSaved = descriptionUpdated.savedExpenseMessage()
+        assertThat(descriptionSaved.description).isEqualTo(DESCRIPTION_UPDATED)
+        assertThat(descriptionSaved.expenseDate).isEqualTo(MANUAL_DATE)
+        assertThat(descriptionSaved.categoryName).isEqualTo(newCategory.name)
+        assertThat(descriptionUpdated.nextState).isEqualTo(UserState.Idle)
+
+        val saved = expenseById(userId, createdExpense.first.id)
+        assertThat(saved.amount).isEqualTo(EXPENSE_AMOUNT_UPDATED)
+        assertThat(saved.categoryId).isEqualTo(newCategory.id)
+        assertThat(saved.expenseDate).isEqualTo(MANUAL_DATE)
+        assertThat(saved.description).isEqualTo(DESCRIPTION_UPDATED)
+        assertThat(saved.id).isEqualTo(createdExpense.first.id)
+    }
+
+    @Test
+    fun `edit unavailable expense from card shows unavailable message and resets state`() {
+        val userId = 2012L
+        val chatId = 3012L
+
+        val unavailableMessage =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                callbackData = CallbackData.editExpense(UUID.fromString("00000000-0000-0000-0000-000000000001")),
+                callbackMessageId = CARD_MESSAGE_ID,
+            )
+
+        assertThat(
+            unavailableMessage.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.ExpenseUnavailable)
+        assertThat(
+            unavailableMessage.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ClearInlineKeyboard)
+        assertThat(unavailableMessage.nextState).isEqualTo(UserState.Idle)
+        assertThat(
+            unavailableMessage.response.outgoingMessages
+                .single()
+                .delivery,
+        ).isEqualTo(ResponseDelivery.EditMessage(CARD_MESSAGE_ID))
+    }
+
+    @Test
+    fun `edit with invalid field repeats field selection`() {
+        val userId = 2013L
+        val chatId = 3013L
+
+        val createdExpense = createExpense(userId, chatId)
+        val editStart =
+            requestEdit(userId = userId, chatId = chatId, expenseId = createdExpense.first.id, callbackMessageId = CARD_MESSAGE_ID)
+        val invalidFieldResult =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = "Неверная кнопка",
+            )
+        assertThat(invalidFieldResult.response.outgoingMessages).isNotEmpty
+        val firstMessage = invalidFieldResult.response.outgoingMessages.first()
+        assertThat(firstMessage.text).isEqualTo(BotText.EditExpenseFieldSelection)
+        assertThat(firstMessage.actions).containsExactly(BotAction.ShowExpenseEditFieldSelection)
+        assertThat(invalidFieldResult.nextState).isEqualTo(UserState.AwaitingExpenseEditFieldSelection(createdExpense.first.id))
+        assertThat(firstMessage.delivery)
+            .isEqualTo(ResponseDelivery.SendNewMessage)
+        assertThat(editStart.response.outgoingMessages).isNotEmpty
+        assertThat(
+            editStart.response.outgoingMessages
+                .first()
+                .delivery,
+        ).isEqualTo(ResponseDelivery.EditMessage(CARD_MESSAGE_ID))
+    }
+
+    private fun createExpense(
+        userId: Long,
+        chatId: Long,
+    ): Pair<Expense, Category> {
+        startExpenseInput(userId, chatId)
+        val categorySelection = submitExpenseForCategorySelection(userId, chatId, EXPENSE_TEXT_WITH_DESCRIPTION)
+        val category =
+            categorySelection.categories.firstOrNull { it.name == "Транспорт" }
+                ?: categorySelection.categories.first()
+        selectCategoryForDateSelection(userId, chatId, category, EXPENSE_WITH_DESCRIPTION)
+        val savedResult = selectTodayDate(userId, chatId)
+        assertThat(savedResult.response.outgoingMessages).hasSize(2)
+        val savedMessage = savedResult.savedExpenseMessage()
+        assertThat(savedMessage.amount).isEqualTo(EXPENSE_AMOUNT)
+        assertThat(savedMessage.categoryName).isEqualTo(category.name)
+        val expense = findExpenses(userId).single()
+        assertThat(expense).isNotNull
+        return expense to category
+    }
+
+    private fun startExpenseInput(
+        userId: Long,
+        chatId: Long,
+    ) {
+        dialogueRouter.processUserInput(userId = userId, chatId = chatId, text = "/start")
+        dialogueRouter.processUserInput(userId = userId, chatId = chatId, callbackData = CallbackData.menuAddExpense())
+    }
+
+    private fun selectTodayDate(
+        userId: Long,
+        chatId: Long,
+    ): me.kmozze.expensetracker.model.domain.HandlerResult =
+        dialogueRouter.processUserInput(
+            userId = userId,
+            chatId = chatId,
+            text = Buttons.TODAY,
+        )
+
+    private fun submitExpenseForCategorySelection(
+        userId: Long,
+        chatId: Long,
+        expenseText: String,
+    ): CategorySelection {
+        val result =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = expenseText,
+            )
+        val action = result.categorySelectionAction()
+
+        assertThat(action.categories).isNotEmpty()
+
+        return CategorySelection(result, action.categories)
+    }
+
+    private fun selectCategoryForDateSelection(
+        userId: Long,
+        chatId: Long,
+        category: Category,
+        expenseDraft: ExpenseDraft,
+    ): me.kmozze.expensetracker.model.domain.HandlerResult {
+        val result =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = category.name,
+            )
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowExpenseDateSelection)
+        assertThat(result.nextState)
+            .isEqualTo(
+                UserState.AwaitingExpenseDateSelection(
+                    expenseDraft = expenseDraft.copy(categoryId = category.id),
+                    categoryName = category.name,
+                ),
+            )
+
+        return result
+    }
+
+    private fun requestEdit(
+        userId: Long,
+        chatId: Long,
+        expenseId: UUID,
+        callbackMessageId: Int,
+    ) = dialogueRouter.processUserInput(
+        userId = userId,
+        chatId = chatId,
+        callbackData = CallbackData.editExpense(expenseId),
+        callbackMessageId = callbackMessageId,
+    )
+
+    private fun expenseById(
+        userId: Long,
+        expenseId: UUID,
+    ): Expense =
+        expenseRepository
+            .findAllByUserIdAndPeriod(
+                userId = userId,
+                from = TEST_PERIOD_FROM,
+                to = TEST_PERIOD_TO,
+            ).single { it.id == expenseId }
+
+    private fun findExpenses(userId: Long): List<Expense> =
+        expenseRepository.findAllByUserIdAndPeriod(
+            userId = userId,
+            from = TEST_PERIOD_FROM,
+            to = TEST_PERIOD_TO,
+        )
+
+    private fun me.kmozze.expensetracker.model.domain.HandlerResult.categorySelectionAction(): BotAction.ShowCategorySelection =
+        response.outgoingMessages
+            .single()
+            .actions
+            .single() as BotAction.ShowCategorySelection
+
+    private fun me.kmozze.expensetracker.model.domain.HandlerResult.savedExpenseMessage(): BotText.ExpenseSaved {
+        assertThat(response.outgoingMessages).hasSize(2)
+        return response.outgoingMessages[1].text as BotText.ExpenseSaved
+    }
+
+    private fun me.kmozze.expensetracker.model.domain.HandlerResult.expenseCardAction(): BotAction.ShowExpenseCardActions =
+        response.outgoingMessages[1].actions.single() as BotAction.ShowExpenseCardActions
+
+    private data class CategorySelection(
+        val result: me.kmozze.expensetracker.model.domain.HandlerResult,
+        val categories: List<Category>,
+    )
+
+    private companion object {
+        const val EXPENSE_TEXT_WITH_DESCRIPTION = "500 такси"
+        const val DESCRIPTION_UPDATED = "Рабочая встреча"
+        const val EXPENSE_DESCRIPTION_UPDATED = "такси"
+        const val MANUAL_DATE_TEXT = "20.05.2026"
+        val MANUAL_DATE: LocalDate = LocalDate.parse("2026-05-20")
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        val EXPENSE_AMOUNT_UPDATED: Money = Money.of(BigDecimal("650.00"))
+        val EXPENSE_WITH_DESCRIPTION: ExpenseDraft = ExpenseDraft(EXPENSE_AMOUNT, EXPENSE_DESCRIPTION_UPDATED)
+        val TEST_PERIOD_FROM: OffsetDateTime = OffsetDateTime.parse("2000-01-01T00:00:00Z")
+        val TEST_PERIOD_TO: OffsetDateTime = OffsetDateTime.parse("2100-01-01T00:00:00Z")
+        const val CARD_MESSAGE_ID = 777
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/ui/KeyboardApplierTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/ui/KeyboardApplierTest.kt
@@ -44,6 +44,17 @@ class KeyboardApplierTest {
     }
 
     @Test
+    fun `send message uses reply keyboard for edit field selection`() {
+        val sendMessage = SendMessage("123", "text")
+
+        keyboardApplier.apply(sendMessage, listOf(BotAction.ShowExpenseEditFieldSelection))
+
+        val keyboard = sendMessage.replyMarkup as ReplyKeyboardMarkup
+        assertThat(keyboard.keyboard).hasSize(3)
+        assertThat(keyboard.keyboard[0]).hasSize(2)
+    }
+
+    @Test
     fun `send message uses inline keyboard for expense card actions`() {
         val sendMessage = SendMessage("123", "text")
 

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/ui/MessageFormatterTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/ui/MessageFormatterTest.kt
@@ -142,4 +142,34 @@ class MessageFormatterTest {
                     "Введите дату траты в формате ДД.ММ.ГГГГ.",
             )
     }
+
+    @Test
+    fun `editable expense message adds edit hint`() {
+        val text =
+            formatter.format(
+                BotText.ExpenseEditable(
+                    amount = Money.of(BigDecimal("500.00")),
+                    categoryName = "Транспорт",
+                    expenseDate = LocalDate.parse("2026-05-24"),
+                    description = "такси",
+                ),
+            )
+
+        assertThat(text)
+            .isEqualTo(
+                "✅ Сохранено!\n" +
+                    "💰 Сумма: 500.00 ₽\n" +
+                    "📂 Категория: Транспорт\n" +
+                    "📅 Дата: 24.05.2026\n" +
+                    "📝 такси\n\n" +
+                    "Эта карточка открыта для редактирования ниже.",
+            )
+    }
+
+    @Test
+    fun `edit amount and description prompts`() {
+        assertThat(formatter.format(BotText.EditExpenseFieldSelection)).isEqualTo("Что изменить?")
+        assertThat(formatter.format(BotText.EnterExpenseAmount)).isEqualTo("Введите новую сумму")
+        assertThat(formatter.format(BotText.EnterExpenseDescription)).isEqualTo("Введите новое описание")
+    }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
@@ -220,6 +220,31 @@ class RoutingHandlerTest {
         assertThat(awaitingManualDateHandler.calls).isEmpty()
     }
 
+    @Test
+    fun `card action callback during amount edit returns callback answer without routing`() {
+        val userId = 48L
+        val awaitingAmountEditHandler = RecordingStateHandler(UserState.AwaitingExpenseAmountEdit::class)
+        val expenseId = UUID.fromString("c3a0e10f-cf0d-4f95-8a12-123456789abc")
+        val currentState = UserState.AwaitingExpenseAmountEdit(expenseId = expenseId)
+        val router = routerWith(awaitingAmountEditHandler)
+
+        userSessionService.setState(userId, currentState)
+        val result =
+            router.process(
+                makeUserInput(
+                    userId = userId,
+                    chatId = 1L,
+                    callbackData = CallbackData.deleteExpense(UUID.randomUUID()),
+                ),
+            )
+
+        assertThat(result.response.outgoingMessages).isEmpty()
+        assertThat(result.response.callbackAnswer?.text).isEqualTo(BotText.FinishCurrentDialog)
+        assertThat(result.response.callbackAnswer?.showAlert).isTrue()
+        assertThat(userSessionService.getState(userId)).isEqualTo(currentState)
+        assertThat(awaitingAmountEditHandler.calls).isEmpty()
+    }
+
     private fun routerWith(vararg stateHandlers: StateHandler): DialogueRouter =
         DialogueRouter(
             userSessionService = userSessionService,

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseAmountEditHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseAmountEditHandlerTest.kt
@@ -1,0 +1,169 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import me.kmozze.expensetracker.exception.BusinessErrorCode
+import me.kmozze.expensetracker.exception.exception
+import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseAmountEditHandler
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.UserCommand
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import me.kmozze.expensetracker.support.makeUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class AwaitingExpenseAmountEditHandlerTest {
+    private val expenseService: ExpenseService = mockk()
+    private val categoryService: CategoryService = mockk()
+    private lateinit var handler: AwaitingExpenseAmountEditHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler =
+            AwaitingExpenseAmountEditHandler(
+                expenseService = expenseService,
+                categoryService = categoryService,
+            )
+    }
+
+    @Test
+    fun `valid amount updates expense and returns idle`() {
+        val updatedAmount = Money.of(BigDecimal("650.00"))
+        every { expenseService.parseExpenseAmount("650") } returns updatedAmount
+        every { expenseService.updateExpenseAmountForUser(USER_ID, EXPENSE_ID, updatedAmount) } returns expense(amount = updatedAmount)
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns expense(amount = updatedAmount)
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.PlainText("650"))
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[0].actions).containsExactly(BotAction.RemoveReplyKeyboard)
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = updatedAmount,
+                    categoryName = CATEGORY.name,
+                    expenseDate = EXPENSE_DATE,
+                    description = EXPENSE_DESCRIPTION,
+                ),
+            )
+        assertThat(result.response.outgoingMessages[1].actions).containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.parseExpenseAmount("650") }
+        verify(exactly = 1) { expenseService.updateExpenseAmountForUser(USER_ID, EXPENSE_ID, updatedAmount) }
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `invalid amount keeps amount prompt with error text`() {
+        every { expenseService.parseExpenseAmount("abc") } throws BusinessErrorCode.INVALID_EXPENSE_AMOUNT.exception()
+
+        val result = handle(UserCommand.PlainText("abc"))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.Error(BusinessErrorCode.INVALID_EXPENSE_AMOUNT))
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCancel)
+        assertThat(result.nextState).isEqualTo(AWAITING_EXPENSE_AMOUNT_EDIT)
+        verify(exactly = 1) { expenseService.parseExpenseAmount("abc") }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `cancel returns updated expense card and finishes dialog`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns expense()
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.Cancel)
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[0].actions).containsExactly(BotAction.RemoveReplyKeyboard)
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = EXPENSE_AMOUNT,
+                    categoryName = CATEGORY.name,
+                    expenseDate = EXPENSE_DATE,
+                    description = EXPENSE_DESCRIPTION,
+                ),
+            )
+        assertThat(result.response.outgoingMessages[1].actions).containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    private fun handle(command: UserCommand) =
+        handler.handle(
+            input =
+                makeUserInput(
+                    userId = USER_ID,
+                    chatId = CHAT_ID,
+                    text = textFor(command),
+                    command = command,
+                ),
+            currentState = AWAITING_EXPENSE_AMOUNT_EDIT,
+        )
+
+    private fun textFor(command: UserCommand): String? =
+        when (command) {
+            is UserCommand.PlainText -> command.value
+            else -> null
+        }
+
+    private fun expense(amount: Money = EXPENSE_AMOUNT): Expense =
+        Expense(
+            id = EXPENSE_ID,
+            categoryId = CATEGORY_ID,
+            amount = amount,
+            userId = USER_ID,
+            expenseDate = EXPENSE_DATE,
+            description = EXPENSE_DESCRIPTION,
+        )
+
+    private companion object {
+        const val USER_ID = 123L
+        const val CHAT_ID = 456L
+        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+        val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        val EXPENSE_DATE: LocalDate = LocalDate.parse("2026-05-24")
+        const val EXPENSE_DESCRIPTION = "такси"
+        val CATEGORY: Category =
+            Category(
+                id = CATEGORY_ID,
+                name = "Транспорт",
+                userId = USER_ID,
+            )
+        val AWAITING_EXPENSE_AMOUNT_EDIT: UserState.AwaitingExpenseAmountEdit =
+            UserState.AwaitingExpenseAmountEdit(
+                expenseId = EXPENSE_ID,
+            )
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseCategoryEditHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseCategoryEditHandlerTest.kt
@@ -1,0 +1,227 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import me.kmozze.expensetracker.exception.BusinessErrorCode
+import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseCategoryEditHandler
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.UserCommand
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import me.kmozze.expensetracker.support.makeUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class AwaitingExpenseCategoryEditHandlerTest {
+    private val expenseService: ExpenseService = mockk()
+    private val categoryService: CategoryService = mockk()
+    private lateinit var handler: AwaitingExpenseCategoryEditHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler =
+            AwaitingExpenseCategoryEditHandler(
+                expenseService = expenseService,
+                categoryService = categoryService,
+            )
+    }
+
+    @Test
+    fun `existing category updates expense and updates card`() {
+        val updatedExpense = EXPENSE.copy(categoryId = UPDATED_CATEGORY_ID)
+        every { categoryService.getCategories(USER_ID) } returns listOf(EXISTING_CATEGORY, UPDATED_CATEGORY)
+        every { expenseService.updateExpenseCategoryForUser(USER_ID, EXPENSE_ID, UPDATED_CATEGORY_ID) } returns updatedExpense
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns updatedExpense
+        every { categoryService.findCategoryForUser(UPDATED_CATEGORY_ID, USER_ID) } returns UPDATED_CATEGORY
+
+        val result = handle(UserCommand.PlainText(UPDATED_CATEGORY.name))
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[0].actions)
+            .containsExactly(BotAction.RemoveReplyKeyboard)
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = EXPENSE_AMOUNT,
+                    categoryName = UPDATED_CATEGORY.name,
+                    expenseDate = EXPENSE_DATE,
+                    description = EXPENSE_DESCRIPTION,
+                ),
+            )
+        assertThat(result.response.outgoingMessages[1].actions)
+            .containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { categoryService.getCategories(USER_ID) }
+        verify(exactly = 1) { expenseService.updateExpenseCategoryForUser(USER_ID, EXPENSE_ID, UPDATED_CATEGORY_ID) }
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(UPDATED_CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `missing category repeats selection when categories exist`() {
+        val categories = listOf(EXISTING_CATEGORY, UPDATED_CATEGORY)
+        every { categoryService.getCategories(USER_ID) } returns categories
+
+        val result = handle(UserCommand.PlainText("Нет такой"))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.Error(BusinessErrorCode.CATEGORY_NOT_FOUND))
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCategorySelection(categories))
+        assertThat(result.nextState).isEqualTo(AWAITING_EXPENSE_CATEGORY_EDIT)
+        verify(exactly = 1) { categoryService.getCategories(USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `missing categories closes dialog and returns main menu`() {
+        every { categoryService.getCategories(USER_ID) } returns emptyList()
+
+        val result = handle(UserCommand.PlainText("Нет такой"))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.NoCategories)
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowMainMenu)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { categoryService.getCategories(USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `unavailable expense keeps card unavailable message`() {
+        every { expenseService.updateExpenseCategoryForUser(USER_ID, EXPENSE_ID, UPDATED_CATEGORY_ID) } returns null
+        every { categoryService.getCategories(USER_ID) } returns listOf(EXISTING_CATEGORY, UPDATED_CATEGORY)
+
+        val result = handle(UserCommand.PlainText(UPDATED_CATEGORY.name))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.ExpenseUnavailable)
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(
+            BotAction.ClearInlineKeyboard,
+            BotAction.RemoveReplyKeyboard,
+        )
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { categoryService.getCategories(USER_ID) }
+        verify(exactly = 1) { expenseService.updateExpenseCategoryForUser(USER_ID, EXPENSE_ID, UPDATED_CATEGORY_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `cancel returns card with actions`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(EXISTING_CATEGORY_ID, USER_ID) } returns EXISTING_CATEGORY
+
+        val result = handle(UserCommand.Cancel)
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[0].actions)
+            .containsExactly(BotAction.RemoveReplyKeyboard)
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = EXPENSE_AMOUNT,
+                    categoryName = EXISTING_CATEGORY.name,
+                    expenseDate = EXPENSE_DATE,
+                    description = EXPENSE_DESCRIPTION,
+                ),
+            )
+        assertThat(result.response.outgoingMessages[1].actions)
+            .containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(EXISTING_CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    private fun handle(command: UserCommand): HandlerResult =
+        handler.handle(
+            input =
+                makeUserInput(
+                    userId = USER_ID,
+                    chatId = CHAT_ID,
+                    text = textFor(command),
+                    command = command,
+                ),
+            currentState = AWAITING_EXPENSE_CATEGORY_EDIT,
+        )
+
+    private fun textFor(command: UserCommand): String? =
+        when (command) {
+            is UserCommand.PlainText -> command.value
+            else -> null
+        }
+
+    private companion object {
+        const val USER_ID = 123L
+        const val CHAT_ID = 456L
+        val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val EXISTING_CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+        val UPDATED_CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000003")
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        val EXPENSE_DATE: LocalDate = LocalDate.parse("2026-05-24")
+        const val EXPENSE_DESCRIPTION = "такси"
+        val EXISTING_CATEGORY =
+            Category(
+                id = EXISTING_CATEGORY_ID,
+                name = "Транспорт",
+                userId = USER_ID,
+            )
+        val UPDATED_CATEGORY =
+            Category(
+                id = UPDATED_CATEGORY_ID,
+                name = "Еда",
+                userId = USER_ID,
+            )
+        val EXPENSE =
+            Expense(
+                id = EXPENSE_ID,
+                categoryId = EXISTING_CATEGORY_ID,
+                amount = EXPENSE_AMOUNT,
+                userId = USER_ID,
+                expenseDate = EXPENSE_DATE,
+                description = EXPENSE_DESCRIPTION,
+            )
+        val AWAITING_EXPENSE_CATEGORY_EDIT =
+            UserState.AwaitingExpenseCategoryEdit(
+                expenseId = EXPENSE_ID,
+            )
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateEditManualInputHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateEditManualInputHandlerTest.kt
@@ -1,0 +1,203 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import me.kmozze.expensetracker.exception.BusinessErrorCode
+import me.kmozze.expensetracker.exception.exception
+import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseDateEditManualInputHandler
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.UserCommand
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import me.kmozze.expensetracker.support.makeUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class AwaitingExpenseDateEditManualInputHandlerTest {
+    private val expenseService: ExpenseService = mockk()
+    private val categoryService: CategoryService = mockk()
+    private lateinit var handler: AwaitingExpenseDateEditManualInputHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler =
+            AwaitingExpenseDateEditManualInputHandler(
+                expenseService = expenseService,
+                categoryService = categoryService,
+            )
+    }
+
+    @Test
+    fun `manual date updates expense and returns idle`() {
+        every { expenseService.parseExpenseDate(MANUAL_DATE_TEXT) } returns MANUAL_DATE
+        every { expenseService.updateExpenseDateForUser(USER_ID, EXPENSE_ID, MANUAL_DATE) } returns
+            EXPENSE.copy(expenseDate = MANUAL_DATE)
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns
+            EXPENSE.copy(expenseDate = MANUAL_DATE)
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.PlainText(MANUAL_DATE_TEXT))
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[0].actions).containsExactly(BotAction.RemoveReplyKeyboard)
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = EXPENSE_AMOUNT,
+                    categoryName = CATEGORY.name,
+                    expenseDate = MANUAL_DATE,
+                    description = EXPENSE_DESCRIPTION,
+                ),
+            )
+        assertThat(result.response.outgoingMessages[1].actions)
+            .containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.parseExpenseDate(MANUAL_DATE_TEXT) }
+        verify(exactly = 1) { expenseService.updateExpenseDateForUser(USER_ID, EXPENSE_ID, MANUAL_DATE) }
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `manual date keeps input open with error when invalid`() {
+        every { expenseService.parseExpenseDate("31.02.2026") } throws BusinessErrorCode.EXPENSE_DATE_INVALID_FORMAT.exception()
+
+        val result = handle(UserCommand.PlainText("31.02.2026"))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.Error(BusinessErrorCode.EXPENSE_DATE_INVALID_FORMAT))
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCancel)
+        assertThat(result.nextState).isEqualTo(AWAITING_EXPENSE_DATE_EDIT_MANUAL_INPUT)
+        verify(exactly = 1) { expenseService.parseExpenseDate("31.02.2026") }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `non-text command repeats manual date input`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.RequestExpenseDeletion(EXPENSE_ID))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(
+            BotText.EnterExpenseDateManually(
+                amount = EXPENSE_AMOUNT,
+                categoryName = CATEGORY.name,
+                description = EXPENSE_DESCRIPTION,
+            ),
+        )
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCancel)
+        assertThat(result.nextState).isEqualTo(AWAITING_EXPENSE_DATE_EDIT_MANUAL_INPUT)
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `cancel returns card with actions`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.Cancel)
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[0].actions).containsExactly(BotAction.RemoveReplyKeyboard)
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = EXPENSE_AMOUNT,
+                    categoryName = CATEGORY.name,
+                    expenseDate = EXPENSE_DATE,
+                    description = EXPENSE_DESCRIPTION,
+                ),
+            )
+        assertThat(result.response.outgoingMessages[1].actions)
+            .containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    private fun handle(command: UserCommand): HandlerResult =
+        handler.handle(
+            input =
+                makeUserInput(
+                    userId = USER_ID,
+                    chatId = CHAT_ID,
+                    text = textFor(command),
+                    command = command,
+                ),
+            currentState = AWAITING_EXPENSE_DATE_EDIT_MANUAL_INPUT,
+        )
+
+    private fun textFor(command: UserCommand): String? =
+        when (command) {
+            is UserCommand.PlainText -> command.value
+            else -> null
+        }
+
+    private companion object {
+        const val USER_ID = 123L
+        const val CHAT_ID = 456L
+        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+        val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        const val EXPENSE_DESCRIPTION = "такси"
+        const val MANUAL_DATE_TEXT = "20.05.2026"
+        val MANUAL_DATE: LocalDate = LocalDate.parse("2026-05-20")
+        val EXPENSE_DATE: LocalDate = LocalDate.parse("2026-05-24")
+        val CATEGORY =
+            Category(
+                id = CATEGORY_ID,
+                name = "Транспорт",
+                userId = USER_ID,
+            )
+        val EXPENSE =
+            Expense(
+                id = EXPENSE_ID,
+                categoryId = CATEGORY_ID,
+                amount = EXPENSE_AMOUNT,
+                userId = USER_ID,
+                expenseDate = EXPENSE_DATE,
+                description = EXPENSE_DESCRIPTION,
+            )
+        val AWAITING_EXPENSE_DATE_EDIT_MANUAL_INPUT =
+            UserState.AwaitingExpenseDateEditManualInput(
+                expenseId = EXPENSE_ID,
+            )
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateEditSelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateEditSelectionHandlerTest.kt
@@ -1,0 +1,197 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.exception.BusinessErrorCode
+import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseDateEditSelectionHandler
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.UserCommand
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import me.kmozze.expensetracker.support.makeUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class AwaitingExpenseDateEditSelectionHandlerTest {
+    private val expenseService: ExpenseService = mockk()
+    private val categoryService: CategoryService = mockk()
+    private lateinit var handler: AwaitingExpenseDateEditSelectionHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler =
+            AwaitingExpenseDateEditSelectionHandler(
+                expenseService = expenseService,
+                categoryService = categoryService,
+                clock = CLOCK,
+            )
+    }
+
+    @Test
+    fun `today selection updates date`() {
+        every { expenseService.updateExpenseDateForUser(USER_ID, EXPENSE_ID, TODAY) } returns EXPENSE.copy(expenseDate = TODAY)
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE.copy(expenseDate = TODAY)
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.PlainText(Buttons.TODAY))
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[1].text).isEqualTo(
+            BotText.ExpenseSaved(
+                amount = EXPENSE_AMOUNT,
+                categoryName = CATEGORY.name,
+                expenseDate = TODAY,
+                description = EXPENSE.description,
+            ),
+        )
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.updateExpenseDateForUser(USER_ID, EXPENSE_ID, TODAY) }
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `yesterday selection updates date`() {
+        val yesterday = YESTERDAY
+        every { expenseService.updateExpenseDateForUser(USER_ID, EXPENSE_ID, yesterday) } returns EXPENSE.copy(expenseDate = yesterday)
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE.copy(expenseDate = yesterday)
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.PlainText(Buttons.YESTERDAY))
+
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = EXPENSE_AMOUNT,
+                    categoryName = CATEGORY.name,
+                    expenseDate = yesterday,
+                    description = EXPENSE.description,
+                ),
+            )
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.updateExpenseDateForUser(USER_ID, EXPENSE_ID, yesterday) }
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `manual selection asks for manual date input`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.PlainText(Buttons.ENTER_DATE_MANUALLY))
+
+        val outgoingMessages = result.response.outgoingMessages
+        assertThat(outgoingMessages.single().text).isEqualTo(
+            BotText.EnterExpenseDateManually(
+                amount = EXPENSE_AMOUNT,
+                categoryName = CATEGORY.name,
+                description = EXPENSE.description,
+            ),
+        )
+        assertThat(outgoingMessages.single().actions).containsExactly(BotAction.ShowCancel)
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingExpenseDateEditManualInput(expenseId = EXPENSE_ID))
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `invalid date text repeats selection`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        val result = handle(UserCommand.PlainText("завтра"))
+
+        val outgoingMessages = result.response.outgoingMessages
+        assertThat(outgoingMessages.single().text).isEqualTo(
+            BotText.Error(BusinessErrorCode.INVALID_EXPENSE_DATE_SELECTION),
+        )
+        assertThat(outgoingMessages.single().actions).containsExactly(BotAction.ShowExpenseDateSelection)
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingExpenseDateEditSelection(expenseId = EXPENSE_ID))
+        verify(exactly = 0) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 0) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `cancel returns expense card`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.Cancel)
+
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    private fun handle(command: UserCommand) =
+        handler.handle(
+            input =
+                makeUserInput(
+                    userId = USER_ID,
+                    chatId = CHAT_ID,
+                    text = textFor(command),
+                    command = command,
+                ),
+            currentState = AWAITING_EXPENSE_DATE_EDIT_SELECTION,
+        )
+
+    private fun textFor(command: UserCommand): String? =
+        when (command) {
+            is UserCommand.PlainText -> command.value
+            else -> null
+        }
+
+    private companion object {
+        const val USER_ID = 123L
+        const val CHAT_ID = 456L
+        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+        val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        val CLOCK: Clock = Clock.fixed(Instant.parse("2026-05-24T12:00:00Z"), ZoneOffset.UTC)
+        val TODAY: LocalDate = LocalDate.parse("2026-05-24")
+        val YESTERDAY: LocalDate = LocalDate.parse("2026-05-23")
+        val EXPENSE: Expense =
+            Expense(
+                id = EXPENSE_ID,
+                categoryId = CATEGORY_ID,
+                amount = EXPENSE_AMOUNT,
+                userId = USER_ID,
+                expenseDate = TODAY,
+                description = "такси",
+            )
+        val CATEGORY: Category =
+            Category(
+                id = CATEGORY_ID,
+                name = "Транспорт",
+                userId = USER_ID,
+            )
+        val AWAITING_EXPENSE_DATE_EDIT_SELECTION: UserState.AwaitingExpenseDateEditSelection =
+            UserState.AwaitingExpenseDateEditSelection(
+                expenseId = EXPENSE_ID,
+            )
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDescriptionEditHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDescriptionEditHandlerTest.kt
@@ -1,0 +1,185 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseDescriptionEditHandler
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.HandlerResult
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.UserCommand
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import me.kmozze.expensetracker.support.makeUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class AwaitingExpenseDescriptionEditHandlerTest {
+    private val expenseService: ExpenseService = mockk()
+    private val categoryService: CategoryService = mockk()
+    private lateinit var handler: AwaitingExpenseDescriptionEditHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler =
+            AwaitingExpenseDescriptionEditHandler(
+                expenseService = expenseService,
+                categoryService = categoryService,
+            )
+    }
+
+    @Test
+    fun `description text updates expense and returns idle`() {
+        every { expenseService.updateExpenseDescriptionForUser(USER_ID, EXPENSE_ID, NEW_EXPENSE_DESCRIPTION) } returns
+            EXPENSE.copy(description = NEW_EXPENSE_DESCRIPTION)
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns
+            EXPENSE.copy(description = NEW_EXPENSE_DESCRIPTION)
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.PlainText(NEW_EXPENSE_DESCRIPTION))
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[0].actions).containsExactly(BotAction.RemoveReplyKeyboard)
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = EXPENSE_AMOUNT,
+                    categoryName = CATEGORY.name,
+                    expenseDate = EXPENSE_DATE,
+                    description = NEW_EXPENSE_DESCRIPTION,
+                ),
+            )
+        assertThat(result.response.outgoingMessages[1].actions)
+            .containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.updateExpenseDescriptionForUser(USER_ID, EXPENSE_ID, NEW_EXPENSE_DESCRIPTION) }
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `cancel returns card with actions`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.Cancel)
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[0].actions).containsExactly(BotAction.RemoveReplyKeyboard)
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = EXPENSE_AMOUNT,
+                    categoryName = CATEGORY.name,
+                    expenseDate = EXPENSE_DATE,
+                    description = EXPENSE_DESCRIPTION,
+                ),
+            )
+        assertThat(result.response.outgoingMessages[1].actions)
+            .containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `non-description command repeats description input`() {
+        val result = handle(UserCommand.Categories)
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.EnterExpenseDescription)
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCancel)
+        assertThat(result.nextState).isEqualTo(AWAITING_EXPENSE_DESCRIPTION_EDIT)
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `whitespace description repeats description input`() {
+        val result = handle(UserCommand.PlainText("   "))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.EnterExpenseDescription)
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCancel)
+        assertThat(result.nextState).isEqualTo(AWAITING_EXPENSE_DESCRIPTION_EDIT)
+        verify(exactly = 0) { expenseService.updateExpenseDescriptionForUser(any(), any(), any()) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    private fun handle(command: UserCommand): HandlerResult =
+        handler.handle(
+            input =
+                makeUserInput(
+                    userId = USER_ID,
+                    chatId = CHAT_ID,
+                    text = textFor(command),
+                    command = command,
+                ),
+            currentState = AWAITING_EXPENSE_DESCRIPTION_EDIT,
+        )
+
+    private fun textFor(command: UserCommand): String? =
+        when (command) {
+            is UserCommand.PlainText -> command.value
+            else -> null
+        }
+
+    private companion object {
+        const val USER_ID = 123L
+        const val CHAT_ID = 456L
+        const val EXPENSE_DESCRIPTION = "такси"
+        const val NEW_EXPENSE_DESCRIPTION = "автобус"
+        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+        val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        val EXPENSE_DATE: LocalDate = LocalDate.parse("2026-05-24")
+        val CATEGORY =
+            Category(
+                id = CATEGORY_ID,
+                name = "Транспорт",
+                userId = USER_ID,
+            )
+        val EXPENSE =
+            Expense(
+                id = EXPENSE_ID,
+                categoryId = CATEGORY_ID,
+                amount = EXPENSE_AMOUNT,
+                userId = USER_ID,
+                expenseDate = EXPENSE_DATE,
+                description = EXPENSE_DESCRIPTION,
+            )
+        val AWAITING_EXPENSE_DESCRIPTION_EDIT =
+            UserState.AwaitingExpenseDescriptionEdit(
+                expenseId = EXPENSE_ID,
+            )
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseEditFieldSelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseEditFieldSelectionHandlerTest.kt
@@ -1,0 +1,240 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseEditFieldSelectionHandler
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.UserCommand
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import me.kmozze.expensetracker.support.makeUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class AwaitingExpenseEditFieldSelectionHandlerTest {
+    private val expenseService: ExpenseService = mockk()
+    private val categoryService: CategoryService = mockk()
+    private lateinit var handler: AwaitingExpenseEditFieldSelectionHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler =
+            AwaitingExpenseEditFieldSelectionHandler(
+                expenseService = expenseService,
+                categoryService = categoryService,
+            )
+    }
+
+    @Test
+    fun `amount selection asks for amount text`() {
+        val result = handle(UserCommand.PlainText(Buttons.EDIT_EXPENSE_AMOUNT))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.EnterExpenseAmount)
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCancel)
+        assertThat(result.nextState)
+            .isEqualTo(
+                UserState.AwaitingExpenseAmountEdit(
+                    expenseId = EXPENSE_ID,
+                ),
+            )
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `description selection asks for description text`() {
+        val result = handle(UserCommand.PlainText(Buttons.EDIT_EXPENSE_DESCRIPTION))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.EnterExpenseDescription)
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCancel)
+        assertThat(result.nextState)
+            .isEqualTo(
+                UserState.AwaitingExpenseDescriptionEdit(
+                    expenseId = EXPENSE_ID,
+                ),
+            )
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `category selection shows categories`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.getCategories(USER_ID) } returns listOf(CATEGORY)
+
+        val result = handle(UserCommand.PlainText(Buttons.EDIT_EXPENSE_CATEGORY))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.SelectCategory(amount = EXPENSE_AMOUNT, description = EXPENSE.description))
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowCategorySelection(listOf(CATEGORY)))
+        assertThat(result.nextState)
+            .isEqualTo(UserState.AwaitingExpenseCategoryEdit(expenseId = EXPENSE_ID))
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.getCategories(USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `date selection opens date choice`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.PlainText(Buttons.EDIT_EXPENSE_DATE))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(
+            BotText.SelectExpenseDate(
+                amount = EXPENSE_AMOUNT,
+                categoryName = CATEGORY.name,
+                description = EXPENSE.description,
+            ),
+        )
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowExpenseDateSelection)
+        assertThat(result.nextState)
+            .isEqualTo(
+                UserState.AwaitingExpenseDateEditSelection(
+                    expenseId = EXPENSE_ID,
+                ),
+            )
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `invalid field selection repeats with same state`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+
+        val result = handle(UserCommand.PlainText("Неверно"))
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.EditExpenseFieldSelection)
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ShowExpenseEditFieldSelection)
+        assertThat(result.nextState).isEqualTo(UserState.AwaitingExpenseEditFieldSelection(EXPENSE_ID))
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `cancel returns card with actions`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result = handle(UserCommand.Cancel)
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[0].actions).containsExactly(BotAction.RemoveReplyKeyboard)
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = EXPENSE_AMOUNT,
+                    categoryName = CATEGORY.name,
+                    expenseDate = EXPENSE_DATE,
+                    description = EXPENSE.description,
+                ),
+            )
+        assertThat(result.response.outgoingMessages[1].actions)
+            .containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    private fun handle(command: UserCommand) =
+        handler.handle(
+            input =
+                makeUserInput(
+                    userId = USER_ID,
+                    chatId = CHAT_ID,
+                    text = textFor(command),
+                    command = command,
+                ),
+            currentState = AWAITING_EXPENSE_EDIT_FIELD_SELECTION,
+        )
+
+    private fun textFor(command: UserCommand): String? =
+        when (command) {
+            is UserCommand.PlainText -> command.value
+            else -> null
+        }
+
+    private companion object {
+        const val USER_ID = 123L
+        const val CHAT_ID = 456L
+        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+        val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        val EXPENSE_DATE: LocalDate = LocalDate.parse("2026-05-24")
+        val CATEGORY: Category =
+            Category(
+                id = CATEGORY_ID,
+                name = "Транспорт",
+                userId = USER_ID,
+            )
+        val EXPENSE: Expense =
+            Expense(
+                id = EXPENSE_ID,
+                categoryId = CATEGORY_ID,
+                amount = EXPENSE_AMOUNT,
+                userId = USER_ID,
+                expenseDate = EXPENSE_DATE,
+                description = "такси",
+            )
+        val AWAITING_EXPENSE_EDIT_FIELD_SELECTION: UserState.AwaitingExpenseEditFieldSelection =
+            UserState.AwaitingExpenseEditFieldSelection(
+                expenseId = EXPENSE_ID,
+            )
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/ExpenseEditStateHelpersTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/ExpenseEditStateHelpersTest.kt
@@ -1,0 +1,100 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import me.kmozze.expensetracker.handler.statehandler.buildUpdatedExpenseResult
+import me.kmozze.expensetracker.handler.statehandler.expenseEditUnavailableResult
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class ExpenseEditStateHelpersTest {
+    private val expenseService: ExpenseService = mockk()
+    private val categoryService: CategoryService = mockk()
+
+    @Test
+    fun `build updated expense result contains done and card with actions`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result =
+            buildUpdatedExpenseResult(
+                expenseService = expenseService,
+                categoryService = categoryService,
+                userId = USER_ID,
+                expenseId = EXPENSE_ID,
+                nextState = UserState.Idle,
+                prefixText = BotText.Done,
+            )
+
+        assertThat(result.response.outgoingMessages).hasSize(2)
+        assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
+        assertThat(result.response.outgoingMessages[0].actions).containsExactly(BotAction.RemoveReplyKeyboard)
+        assertThat(result.response.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseSaved(
+                    amount = EXPENSE.amount,
+                    categoryName = CATEGORY.name,
+                    expenseDate = EXPENSE.expenseDate,
+                    description = EXPENSE.description,
+                ),
+            )
+        assertThat(result.response.outgoingMessages[1].actions)
+            .containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `expense edit unavailable removes inline keyboard and reply keyboard`() {
+        val result = expenseEditUnavailableResult()
+        val outgoingMessage = result.response.outgoingMessages.single()
+
+        assertThat(outgoingMessage.text)
+            .isEqualTo(BotText.ExpenseUnavailable)
+        assertThat(outgoingMessage.actions)
+            .containsExactly(BotAction.ClearInlineKeyboard, BotAction.RemoveReplyKeyboard)
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+    }
+
+    private companion object {
+        const val USER_ID = 123L
+        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+        val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        val EXPENSE_DATE: LocalDate = LocalDate.parse("2026-05-24")
+        val CATEGORY =
+            Category(
+                id = CATEGORY_ID,
+                name = "Транспорт",
+                userId = USER_ID,
+            )
+        val EXPENSE =
+            Expense(
+                id = EXPENSE_ID,
+                categoryId = CATEGORY_ID,
+                amount = EXPENSE_AMOUNT,
+                userId = USER_ID,
+                expenseDate = EXPENSE_DATE,
+                description = "такси",
+            )
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/IdleStateHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/IdleStateHandlerTest.kt
@@ -169,6 +169,79 @@ class IdleStateHandlerTest {
     }
 
     @Test
+    fun `request expense edit opens field selection`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result =
+            handler.handle(
+                input = makeInput(UserCommand.RequestExpenseEdit(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                currentState = UserState.Idle,
+            )
+
+        assertThat(
+            result.response.outgoingMessages[0]
+                .text,
+        ).isEqualTo(
+            BotText.ExpenseEditable(
+                amount = EXPENSE_AMOUNT,
+                categoryName = CATEGORY.name,
+                expenseDate = EXPENSE_DATE,
+                description = EXPENSE_DESCRIPTION,
+            ),
+        )
+        assertThat(
+            result.response.outgoingMessages[0]
+                .actions,
+        ).containsExactly(BotAction.ClearInlineKeyboard)
+        assertThat(
+            result.response.outgoingMessages[0]
+                .delivery,
+        ).isEqualTo(ResponseDelivery.EditMessage(MESSAGE_ID))
+        assertThat(
+            result.response.outgoingMessages[1]
+                .text,
+        ).isEqualTo(BotText.EditExpenseFieldSelection)
+        assertThat(
+            result.response.outgoingMessages[1]
+                .actions,
+        ).containsExactly(BotAction.ShowExpenseEditFieldSelection)
+        assertThat(result.nextState)
+            .isEqualTo(UserState.AwaitingExpenseEditFieldSelection(expenseId = EXPENSE_ID))
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+    }
+
+    @Test
+    fun `request expense edit returns unavailable when expense is missing`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns null
+
+        val result =
+            handler.handle(
+                input = makeInput(UserCommand.RequestExpenseEdit(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                currentState = UserState.Idle,
+            )
+
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(BotText.ExpenseUnavailable)
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactly(BotAction.ClearInlineKeyboard)
+        assertThat(
+            result.response.outgoingMessages
+                .single()
+                .delivery,
+        ).isEqualTo(ResponseDelivery.EditMessage(MESSAGE_ID))
+        assertThat(result.nextState).isEqualTo(UserState.Idle)
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+    }
+
+    @Test
     fun `cancel expense deletion restores card actions`() {
         every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
         every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
@@ -335,7 +408,6 @@ class IdleStateHandlerTest {
                 UserCommand.ViewExpenses,
                 UserCommand.Categories,
                 UserCommand.Statistics,
-                UserCommand.RequestExpenseEdit(EXPENSE_ID),
             )
 
         @JvmStatic

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/service/ExpenseServiceTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/service/ExpenseServiceTest.kt
@@ -6,6 +6,8 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import me.kmozze.expensetracker.exception.BusinessErrorCode
+import me.kmozze.expensetracker.exception.BusinessException
 import me.kmozze.expensetracker.exception.SystemErrorCode
 import me.kmozze.expensetracker.exception.SystemException
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
@@ -107,6 +109,111 @@ class ExpenseServiceTest {
         assertEquals(cause, exception.cause)
         verify(exactly = 1) { expenseRepository.findByIdForUser(expenseId, userId) }
         confirmVerified(expenseTextParser, expenseDateParser, expenseRepository)
+    }
+
+    @Test
+    fun `update expense amount for user updates existing expense`() {
+        val userId = 123L
+        val expenseId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val expenseDate = LocalDate.parse("2026-05-24")
+        val original =
+            Expense(
+                id = expenseId,
+                categoryId = categoryId,
+                amount = EXPENSE_AMOUNT,
+                userId = userId,
+                expenseDate = expenseDate,
+            )
+        val expectedAmount = Money.of(BigDecimal("650.00"))
+        val updatedExpense =
+            original.copy(
+                amount = expectedAmount,
+            )
+        every { expenseRepository.findByIdForUser(expenseId, userId) } returns original
+        every { expenseRepository.updateForUser(updatedExpense, userId) } returns updatedExpense
+
+        val result = service.updateExpenseAmountForUser(userId = userId, expenseId = expenseId, amount = expectedAmount)
+
+        assertEquals(updatedExpense, result)
+        verify(exactly = 1) { expenseRepository.findByIdForUser(expenseId, userId) }
+        verify(exactly = 1) { expenseRepository.updateForUser(updatedExpense, userId) }
+        confirmVerified(expenseTextParser, expenseDateParser, expenseRepository)
+    }
+
+    @Test
+    fun `update expense returns null when expense missing`() {
+        val userId = 123L
+        val expenseId = UUID.randomUUID()
+        every { expenseRepository.findByIdForUser(expenseId, userId) } returns null
+
+        val result = service.updateExpenseAmountForUser(userId = userId, expenseId = expenseId, amount = Money.of(BigDecimal("650.00")))
+
+        assertEquals(null, result)
+        verify(exactly = 1) { expenseRepository.findByIdForUser(expenseId, userId) }
+        verify(exactly = 0) { expenseRepository.updateForUser(any(), any()) }
+        confirmVerified(expenseTextParser, expenseDateParser, expenseRepository)
+    }
+
+    @Test
+    fun `update expense wraps DataAccessException into SystemException`() {
+        val userId = 123L
+        val expenseId = UUID.randomUUID()
+        val categoryId = UUID.randomUUID()
+        val expenseDate = LocalDate.parse("2026-05-24")
+        val original =
+            Expense(
+                id = expenseId,
+                categoryId = categoryId,
+                amount = EXPENSE_AMOUNT,
+                userId = userId,
+                expenseDate = expenseDate,
+            )
+        val cause = DataAccessException("DB update failed")
+        every { expenseRepository.findByIdForUser(expenseId, userId) } returns original
+        every { expenseRepository.updateForUser(any(), userId) } throws cause
+
+        val exception =
+            assertThrows<SystemException> {
+                service.updateExpenseAmountForUser(
+                    userId = userId,
+                    expenseId = expenseId,
+                    amount = Money.of(BigDecimal("650.00")),
+                )
+            }
+
+        assertEquals(SystemErrorCode.DATABASE_ERROR, exception.errorCode)
+        assertEquals(cause, exception.cause)
+        verify(exactly = 1) { expenseRepository.findByIdForUser(expenseId, userId) }
+        verify(exactly = 1) { expenseRepository.updateForUser(any(), userId) }
+        confirmVerified(expenseTextParser, expenseDateParser, expenseRepository)
+    }
+
+    @Test
+    fun `parse expense amount trims spaces`() {
+        val amount = service.parseExpenseAmount(" 650.50 ")
+
+        assertEquals(Money.of(BigDecimal("650.50")), amount)
+    }
+
+    @Test
+    fun `parse expense amount rejects invalid text`() {
+        val exception =
+            assertThrows<BusinessException> {
+                service.parseExpenseAmount("abc")
+            }
+
+        assertEquals(BusinessErrorCode.INVALID_EXPENSE_AMOUNT, exception.errorCode)
+    }
+
+    @Test
+    fun `parse expense amount rejects non-positive values`() {
+        val exception =
+            assertThrows<BusinessException> {
+                service.parseExpenseAmount("0")
+            }
+
+        assertEquals(BusinessErrorCode.INVALID_AMOUNT, exception.errorCode)
     }
 
     @Test


### PR DESCRIPTION
Что сделано:
- Добавлены unit-тесты для новых handler-ов редактирования.
- Добавлен интеграционный flow-тест: сохранение -> редактирование -> обновление карточки.
- Обновлены тесты UI/сервисного слоя под новый контракт редактирования.