### PR TITLE
feat: edit expense user-scoped persistence

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/repository/IExpenseRepository.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/repository/IExpenseRepository.kt
@@ -7,7 +7,10 @@ import java.util.UUID
 interface IExpenseRepository {
     fun create(expense: Expense): Expense
 
-    fun update(expense: Expense): Expense
+    fun updateForUser(
+        expense: Expense,
+        userId: Long,
+    ): Expense?
 
     fun deleteByIdForUser(
         id: UUID,

--- a/src/main/kotlin/me/kmozze/expensetracker/repository/JooqExpenseRepository.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/repository/JooqExpenseRepository.kt
@@ -47,17 +47,20 @@ class JooqExpenseRepository(
             .fetchSingle()
             .toDomain()
 
-    override fun update(expense: Expense): Expense =
+    override fun updateForUser(
+        expense: Expense,
+        userId: Long,
+    ): Expense? =
         dsl
             .update(EXPENSE)
             .set(EXPENSE.AMOUNT, expense.amount.value)
             .set(EXPENSE.CATEGORY_ID, expense.categoryId)
             .set(EXPENSE.EXPENSE_DATE, expense.expenseDate)
             .set(EXPENSE.DESCRIPTION, expense.description)
-            .where(EXPENSE.ID.eq(expense.id))
+            .where(EXPENSE.ID.eq(expense.id).and(EXPENSE.USER_ID.eq(userId)))
             .returning()
-            .fetchSingle()
-            .toDomain()
+            .fetchOne()
+            ?.toDomain()
 
     override fun deleteByIdForUser(
         id: UUID,

--- a/src/main/kotlin/me/kmozze/expensetracker/service/ExpenseService.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/service/ExpenseService.kt
@@ -1,8 +1,10 @@
 package me.kmozze.expensetracker.service
 
+import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.exception.SystemErrorCode
 import me.kmozze.expensetracker.exception.exception
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.entity.Expense
 import me.kmozze.expensetracker.repository.IExpenseRepository
 import me.kmozze.expensetracker.service.parser.InputExpenseDateParsingService
@@ -11,6 +13,7 @@ import org.jooq.exception.DataAccessException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.util.UUID
 
@@ -31,6 +34,21 @@ class ExpenseService(
 
     fun parseExpenseDate(text: String): LocalDate = expenseDateParser.parse(text)
 
+    fun parseExpenseAmount(text: String): Money {
+        val amount =
+            try {
+                BigDecimal(text.trim().replace(',', '.').trim())
+            } catch (e: NumberFormatException) {
+                throw BusinessErrorCode.INVALID_EXPENSE_AMOUNT.exception()
+            }
+
+        val money = Money.of(amount)
+        if (money.value <= BigDecimal.ZERO) {
+            throw BusinessErrorCode.INVALID_AMOUNT.exception()
+        }
+        return money
+    }
+
     fun findExpenseForUser(
         userId: Long,
         expenseId: UUID,
@@ -48,6 +66,34 @@ class ExpenseService(
                 cause = e,
             )
         }
+
+    @Transactional
+    fun updateExpenseAmountForUser(
+        userId: Long,
+        expenseId: UUID,
+        amount: Money,
+    ): Expense? = updateExpense(userId, expenseId) { it.copy(amount = amount) }
+
+    @Transactional
+    fun updateExpenseCategoryForUser(
+        userId: Long,
+        expenseId: UUID,
+        categoryId: UUID,
+    ): Expense? = updateExpense(userId, expenseId) { it.copy(categoryId = categoryId) }
+
+    @Transactional
+    fun updateExpenseDateForUser(
+        userId: Long,
+        expenseId: UUID,
+        expenseDate: LocalDate,
+    ): Expense? = updateExpense(userId, expenseId) { it.copy(expenseDate = expenseDate) }
+
+    @Transactional
+    fun updateExpenseDescriptionForUser(
+        userId: Long,
+        expenseId: UUID,
+        description: String?,
+    ): Expense? = updateExpense(userId, expenseId) { it.copy(description = description?.trim()?.ifEmpty { null }) }
 
     @Transactional
     fun saveExpense(
@@ -91,6 +137,23 @@ class ExpenseService(
 
             throw SystemErrorCode.DATABASE_ERROR.exception(
                 customMessage = "Ошибка при удалении расхода $expenseId",
+                cause = e,
+            )
+        }
+
+    private fun updateExpense(
+        userId: Long,
+        expenseId: UUID,
+        transform: (Expense) -> Expense,
+    ): Expense? =
+        try {
+            val existingExpense = expenseRepository.findByIdForUser(expenseId, userId) ?: return null
+            expenseRepository.updateForUser(transform(existingExpense), userId)
+        } catch (e: DataAccessException) {
+            logger.error("Failed to update expense $expenseId for user $userId", e)
+
+            throw SystemErrorCode.DATABASE_ERROR.exception(
+                customMessage = "Ошибка при обновлении расхода $expenseId",
                 cause = e,
             )
         }


### PR DESCRIPTION
Что сделано:
- Перевел обновления расходов на user-scoped обновления.
- Добавил методы репозитория и сервиса updateForUser + методы обновления суммы/категории/даты/описания.
- Добавлена защита от обновления чужих расходов.

Пройденные проверки: см. связанный PR 1, в котором уже закрыты базовые проверки флоу.