### PR TITLE
Убрать зависимость handler-слоя от Buttons

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/adapter/input/UserCommandParser.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/adapter/input/UserCommandParser.kt
@@ -1,6 +1,8 @@
 package me.kmozze.expensetracker.adapter.input
 
 import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.model.domain.ExpenseDateChoice
+import me.kmozze.expensetracker.model.domain.ExpenseEditField
 import me.kmozze.expensetracker.model.domain.UserCommand
 
 object UserCommandParser {
@@ -13,6 +15,13 @@ object UserCommandParser {
             text?.equals("/start", ignoreCase = true) == true -> UserCommand.Start
             text?.equals("/menu", ignoreCase = true) == true -> UserCommand.Menu
             text == Buttons.CANCEL -> UserCommand.Cancel
+            text == Buttons.TODAY -> UserCommand.SelectExpenseDate(ExpenseDateChoice.Today)
+            text == Buttons.YESTERDAY -> UserCommand.SelectExpenseDate(ExpenseDateChoice.Yesterday)
+            text == Buttons.ENTER_DATE_MANUALLY -> UserCommand.SelectExpenseDate(ExpenseDateChoice.ManualInput)
+            text == Buttons.EDIT_EXPENSE_AMOUNT -> UserCommand.SelectExpenseEditField(ExpenseEditField.Amount)
+            text == Buttons.EDIT_EXPENSE_CATEGORY -> UserCommand.SelectExpenseEditField(ExpenseEditField.Category)
+            text == Buttons.EDIT_EXPENSE_DATE -> UserCommand.SelectExpenseEditField(ExpenseEditField.Date)
+            text == Buttons.EDIT_EXPENSE_DESCRIPTION -> UserCommand.SelectExpenseEditField(ExpenseEditField.Description)
             text != null -> UserCommand.PlainText(text)
             else -> UserCommand.Unsupported
         }

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
@@ -47,6 +47,8 @@ class AwaitingCategorySelectionHandler(
             is UserCommand.RequestExpenseDeletion,
             is UserCommand.ConfirmExpenseDeletion,
             is UserCommand.CancelExpenseDeletion,
+            is UserCommand.SelectExpenseDate,
+            is UserCommand.SelectExpenseEditField,
             UserCommand.InvalidExpenseAction,
             -> repeatCategorySelection(input, currentState)
         }

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDateEditSelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDateEditSelectionHandler.kt
@@ -1,9 +1,9 @@
 package me.kmozze.expensetracker.handler.statehandler
 
-import me.kmozze.expensetracker.adapter.ui.Buttons
 import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseDateChoice
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.HandlerResult
 import me.kmozze.expensetracker.model.domain.OutgoingMessage
@@ -42,7 +42,8 @@ class AwaitingExpenseDateEditSelectionHandler(
                     expenseId = currentState.expenseId,
                 )
 
-            is UserCommand.PlainText -> handleExpenseDateSelection(input, currentState, command.value)
+            is UserCommand.SelectExpenseDate -> handleExpenseDateSelection(input, currentState, command.choice)
+            is UserCommand.PlainText -> expenseDateSelectionError(currentState)
             else -> repeatDateSelection(input, currentState)
         }
     }
@@ -50,39 +51,35 @@ class AwaitingExpenseDateEditSelectionHandler(
     private fun handleExpenseDateSelection(
         input: UserInput,
         currentState: UserState.AwaitingExpenseDateEditSelection,
-        dateText: String,
+        choice: ExpenseDateChoice,
     ): HandlerResult =
-        when (dateText) {
-            Buttons.TODAY ->
+        when (choice) {
+            ExpenseDateChoice.Today,
+            ExpenseDateChoice.Yesterday,
+            ->
                 saveExpenseWithDate(
                     input = input,
                     currentState = currentState,
-                    expenseDate = LocalDate.now(clock),
+                    expenseDate = requireNotNull(choice.toDate(clock)),
                 )
 
-            Buttons.YESTERDAY ->
-                saveExpenseWithDate(
-                    input = input,
-                    currentState = currentState,
-                    expenseDate = LocalDate.now(clock).minusDays(1),
-                )
-
-            Buttons.ENTER_DATE_MANUALLY -> requestManualDateInput(input, currentState)
-            else ->
-                HandlerResult(
-                    response =
-                        HandlerResponse(
-                            outgoingMessages =
-                                listOf(
-                                    OutgoingMessage(
-                                        text = BotText.Error(BusinessErrorCode.INVALID_EXPENSE_DATE_SELECTION),
-                                        actions = listOf(BotAction.ShowExpenseDateSelection),
-                                    ),
-                                ),
-                        ),
-                    nextState = currentState,
-                )
+            ExpenseDateChoice.ManualInput -> requestManualDateInput(input, currentState)
         }
+
+    private fun expenseDateSelectionError(currentState: UserState.AwaitingExpenseDateEditSelection): HandlerResult =
+        HandlerResult(
+            response =
+                HandlerResponse(
+                    outgoingMessages =
+                        listOf(
+                            OutgoingMessage(
+                                text = BotText.Error(BusinessErrorCode.INVALID_EXPENSE_DATE_SELECTION),
+                                actions = listOf(BotAction.ShowExpenseDateSelection),
+                            ),
+                        ),
+                ),
+            nextState = currentState,
+        )
 
     private fun saveExpenseWithDate(
         input: UserInput,

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDateSelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDateSelectionHandler.kt
@@ -1,9 +1,9 @@
 package me.kmozze.expensetracker.handler.statehandler
 
-import me.kmozze.expensetracker.adapter.ui.Buttons
 import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseDateChoice
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.HandlerResult
@@ -35,7 +35,13 @@ class AwaitingExpenseDateSelectionHandler(
 
         return when (val command = input.command) {
             UserCommand.Cancel -> cancelExpenseCreation()
-            is UserCommand.PlainText -> handleExpenseDateSelection(input, currentState, command.value)
+            is UserCommand.SelectExpenseDate -> handleExpenseDateSelection(input, currentState, command.choice)
+            is UserCommand.PlainText ->
+                expenseDateSelectionError(
+                    currentState = currentState,
+                    errorCode = BusinessErrorCode.INVALID_EXPENSE_DATE_SELECTION,
+                )
+
             UserCommand.Unsupported,
             UserCommand.Start,
             UserCommand.Menu,
@@ -47,6 +53,7 @@ class AwaitingExpenseDateSelectionHandler(
             is UserCommand.RequestExpenseDeletion,
             is UserCommand.ConfirmExpenseDeletion,
             is UserCommand.CancelExpenseDeletion,
+            is UserCommand.SelectExpenseEditField,
             UserCommand.InvalidExpenseAction,
             -> repeatExpenseDateSelection(currentState)
         }
@@ -55,17 +62,14 @@ class AwaitingExpenseDateSelectionHandler(
     private fun handleExpenseDateSelection(
         input: UserInput,
         currentState: UserState.AwaitingExpenseDateSelection,
-        text: String,
+        choice: ExpenseDateChoice,
     ): HandlerResult =
-        when (text) {
-            Buttons.TODAY -> saveExpenseWithDate(input, currentState, LocalDate.now(clock))
-            Buttons.YESTERDAY -> saveExpenseWithDate(input, currentState, LocalDate.now(clock).minusDays(1))
-            Buttons.ENTER_DATE_MANUALLY -> requestManualDateInput(currentState)
-            else ->
-                expenseDateSelectionError(
-                    currentState = currentState,
-                    errorCode = BusinessErrorCode.INVALID_EXPENSE_DATE_SELECTION,
-                )
+        when (choice) {
+            ExpenseDateChoice.Today,
+            ExpenseDateChoice.Yesterday,
+            -> saveExpenseWithDate(input, currentState, requireNotNull(choice.toDate(clock)))
+
+            ExpenseDateChoice.ManualInput -> requestManualDateInput(currentState)
         }
 
     private fun saveExpenseWithDate(

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseEditFieldSelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseEditFieldSelectionHandler.kt
@@ -1,8 +1,8 @@
 package me.kmozze.expensetracker.handler.statehandler
 
-import me.kmozze.expensetracker.adapter.ui.Buttons
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseEditField
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.HandlerResult
 import me.kmozze.expensetracker.model.domain.OutgoingMessage
@@ -39,7 +39,7 @@ class AwaitingExpenseEditFieldSelectionHandler(
                     expenseId = currentState.expenseId,
                 )
 
-            is UserCommand.PlainText -> selectEditField(input, currentState, command.value)
+            is UserCommand.SelectExpenseEditField -> selectEditField(input, currentState, command.field)
             else -> repeatEditFieldSelection(input.userId, currentState.expenseId)
         }
     }
@@ -47,10 +47,10 @@ class AwaitingExpenseEditFieldSelectionHandler(
     private fun selectEditField(
         input: UserInput,
         currentState: UserState.AwaitingExpenseEditFieldSelection,
-        selectedField: String,
+        selectedField: ExpenseEditField,
     ): HandlerResult =
         when (selectedField) {
-            Buttons.EDIT_EXPENSE_AMOUNT ->
+            ExpenseEditField.Amount ->
                 HandlerResult(
                     response =
                         HandlerResponse(
@@ -65,11 +65,11 @@ class AwaitingExpenseEditFieldSelectionHandler(
                     nextState = UserState.AwaitingExpenseAmountEdit(currentState.expenseId),
                 )
 
-            Buttons.EDIT_EXPENSE_CATEGORY -> showCategorySelectionForEdit(input, currentState)
+            ExpenseEditField.Category -> showCategorySelectionForEdit(input, currentState)
 
-            Buttons.EDIT_EXPENSE_DATE -> requestDateSelection(input, currentState)
+            ExpenseEditField.Date -> requestDateSelection(input, currentState)
 
-            Buttons.EDIT_EXPENSE_DESCRIPTION ->
+            ExpenseEditField.Description ->
                 HandlerResult(
                     response =
                         HandlerResponse(
@@ -83,8 +83,6 @@ class AwaitingExpenseEditFieldSelectionHandler(
                         ),
                     nextState = UserState.AwaitingExpenseDescriptionEdit(currentState.expenseId),
                 )
-
-            else -> repeatEditFieldSelection(input.userId, currentState.expenseId)
         }
 
     private fun showCategorySelectionForEdit(

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseManualDateInputHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseManualDateInputHandler.kt
@@ -45,6 +45,8 @@ class AwaitingExpenseManualDateInputHandler(
             is UserCommand.RequestExpenseDeletion,
             is UserCommand.ConfirmExpenseDeletion,
             is UserCommand.CancelExpenseDeletion,
+            is UserCommand.SelectExpenseDate,
+            is UserCommand.SelectExpenseEditField,
             UserCommand.InvalidExpenseAction,
             -> repeatManualDateInput(currentState)
         }

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/ExpenseDateChoice.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/ExpenseDateChoice.kt
@@ -1,0 +1,18 @@
+package me.kmozze.expensetracker.model.domain
+
+import java.time.Clock
+import java.time.LocalDate
+
+enum class ExpenseDateChoice {
+    Today,
+    Yesterday,
+    ManualInput,
+    ;
+
+    fun toDate(clock: Clock): LocalDate? =
+        when (this) {
+            Today -> LocalDate.now(clock)
+            Yesterday -> LocalDate.now(clock).minusDays(1)
+            ManualInput -> null
+        }
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/ExpenseEditField.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/ExpenseEditField.kt
@@ -1,0 +1,8 @@
+package me.kmozze.expensetracker.model.domain
+
+enum class ExpenseEditField {
+    Amount,
+    Category,
+    Date,
+    Description,
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/UserCommand.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/UserCommand.kt
@@ -33,6 +33,14 @@ sealed class UserCommand {
         val expenseId: UUID,
     ) : UserCommand()
 
+    data class SelectExpenseDate(
+        val choice: ExpenseDateChoice,
+    ) : UserCommand()
+
+    data class SelectExpenseEditField(
+        val field: ExpenseEditField,
+    ) : UserCommand()
+
     data object InvalidExpenseAction : UserCommand()
 
     data class PlainText(

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/input/CallbackDataParserTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/input/CallbackDataParserTest.kt
@@ -114,8 +114,6 @@ class CallbackDataParserTest {
                 null,
                 "",
                 "unknown",
-                "select_category:$EXPENSE_ID",
-                "select_expense_date:today",
                 "cancel:extra",
             )
     }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/input/UserCommandParserTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/input/UserCommandParserTest.kt
@@ -3,6 +3,8 @@ package me.kmozze.expensetracker.unit.adapter.input
 import me.kmozze.expensetracker.adapter.callback.CallbackData
 import me.kmozze.expensetracker.adapter.input.UserCommandParser
 import me.kmozze.expensetracker.adapter.ui.Buttons
+import me.kmozze.expensetracker.model.domain.ExpenseDateChoice
+import me.kmozze.expensetracker.model.domain.ExpenseEditField
 import me.kmozze.expensetracker.model.domain.UserCommand
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -62,7 +64,6 @@ class UserCommandParserTest {
 
     private companion object {
         val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
-        const val OLD_SELECT_CATEGORY_CALLBACK: String = "select_category:00000000-0000-0000-0000-000000000001"
 
         @JvmStatic
         fun textCommands(): Stream<Arguments> =
@@ -72,8 +73,13 @@ class UserCommandParserTest {
                 Arguments.arguments("/menu", UserCommand.Menu),
                 Arguments.arguments("/MENU", UserCommand.Menu),
                 Arguments.arguments(Buttons.CANCEL, UserCommand.Cancel),
-                Arguments.arguments(Buttons.TODAY, UserCommand.PlainText(Buttons.TODAY)),
-                Arguments.arguments(OLD_SELECT_CATEGORY_CALLBACK, UserCommand.PlainText(OLD_SELECT_CATEGORY_CALLBACK)),
+                Arguments.arguments(Buttons.TODAY, UserCommand.SelectExpenseDate(ExpenseDateChoice.Today)),
+                Arguments.arguments(Buttons.YESTERDAY, UserCommand.SelectExpenseDate(ExpenseDateChoice.Yesterday)),
+                Arguments.arguments(Buttons.ENTER_DATE_MANUALLY, UserCommand.SelectExpenseDate(ExpenseDateChoice.ManualInput)),
+                Arguments.arguments(Buttons.EDIT_EXPENSE_AMOUNT, UserCommand.SelectExpenseEditField(ExpenseEditField.Amount)),
+                Arguments.arguments(Buttons.EDIT_EXPENSE_CATEGORY, UserCommand.SelectExpenseEditField(ExpenseEditField.Category)),
+                Arguments.arguments(Buttons.EDIT_EXPENSE_DATE, UserCommand.SelectExpenseEditField(ExpenseEditField.Date)),
+                Arguments.arguments(Buttons.EDIT_EXPENSE_DESCRIPTION, UserCommand.SelectExpenseEditField(ExpenseEditField.Description)),
             )
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateEditSelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateEditSelectionHandlerTest.kt
@@ -5,11 +5,11 @@ import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
-import me.kmozze.expensetracker.adapter.ui.Buttons
 import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseDateEditSelectionHandler
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseDateChoice
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
@@ -51,7 +51,7 @@ class AwaitingExpenseDateEditSelectionHandlerTest {
         every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE.copy(expenseDate = TODAY)
         every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
 
-        val result = handle(UserCommand.PlainText(Buttons.TODAY))
+        val result = handle(UserCommand.SelectExpenseDate(ExpenseDateChoice.Today))
 
         assertThat(result.response.outgoingMessages).hasSize(2)
         assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
@@ -77,7 +77,7 @@ class AwaitingExpenseDateEditSelectionHandlerTest {
         every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE.copy(expenseDate = yesterday)
         every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
 
-        val result = handle(UserCommand.PlainText(Buttons.YESTERDAY))
+        val result = handle(UserCommand.SelectExpenseDate(ExpenseDateChoice.Yesterday))
 
         assertThat(result.response.outgoingMessages[1].text)
             .isEqualTo(
@@ -100,7 +100,7 @@ class AwaitingExpenseDateEditSelectionHandlerTest {
         every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
         every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
 
-        val result = handle(UserCommand.PlainText(Buttons.ENTER_DATE_MANUALLY))
+        val result = handle(UserCommand.SelectExpenseDate(ExpenseDateChoice.ManualInput))
 
         val outgoingMessages = result.response.outgoingMessages
         assertThat(outgoingMessages.single().text).isEqualTo(

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateSelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateSelectionHandlerTest.kt
@@ -5,11 +5,11 @@ import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
-import me.kmozze.expensetracker.adapter.ui.Buttons
 import me.kmozze.expensetracker.exception.BusinessErrorCode
 import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseDateSelectionHandler
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseDateChoice
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
@@ -47,7 +47,7 @@ class AwaitingExpenseDateSelectionHandlerTest {
         val completeDraft = EXPENSE_DRAFT_WITH_CATEGORY.copy(expenseDate = TODAY)
         every { expenseService.saveExpense(USER_ID, completeDraft) } returns expense(expenseDate = TODAY)
 
-        val result = handle(UserCommand.PlainText(Buttons.TODAY))
+        val result = handle(UserCommand.SelectExpenseDate(ExpenseDateChoice.Today))
 
         assertThat(result.response.outgoingMessages).hasSize(2)
         assertThat(result.response.outgoingMessages[0].text).isEqualTo(BotText.Done)
@@ -72,7 +72,7 @@ class AwaitingExpenseDateSelectionHandlerTest {
         val completeDraft = EXPENSE_DRAFT_WITH_CATEGORY.copy(expenseDate = YESTERDAY)
         every { expenseService.saveExpense(USER_ID, completeDraft) } returns expense(expenseDate = YESTERDAY)
 
-        val result = handle(UserCommand.PlainText(Buttons.YESTERDAY))
+        val result = handle(UserCommand.SelectExpenseDate(ExpenseDateChoice.Yesterday))
 
         assertThat(result.response.outgoingMessages[1].text)
             .isEqualTo(
@@ -90,7 +90,7 @@ class AwaitingExpenseDateSelectionHandlerTest {
 
     @Test
     fun `manual selection asks user to enter date`() {
-        val result = handle(UserCommand.PlainText(Buttons.ENTER_DATE_MANUALLY))
+        val result = handle(UserCommand.SelectExpenseDate(ExpenseDateChoice.ManualInput))
 
         assertThat(
             result.response.outgoingMessages

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseEditFieldSelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseEditFieldSelectionHandlerTest.kt
@@ -5,10 +5,10 @@ import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
-import me.kmozze.expensetracker.adapter.ui.Buttons
 import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseEditFieldSelectionHandler
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseEditField
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
@@ -42,7 +42,7 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
 
     @Test
     fun `amount selection asks for amount text`() {
-        val result = handle(UserCommand.PlainText(Buttons.EDIT_EXPENSE_AMOUNT))
+        val result = handle(UserCommand.SelectExpenseEditField(ExpenseEditField.Amount))
 
         assertThat(
             result.response.outgoingMessages
@@ -65,7 +65,7 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
 
     @Test
     fun `description selection asks for description text`() {
-        val result = handle(UserCommand.PlainText(Buttons.EDIT_EXPENSE_DESCRIPTION))
+        val result = handle(UserCommand.SelectExpenseEditField(ExpenseEditField.Description))
 
         assertThat(
             result.response.outgoingMessages
@@ -91,7 +91,7 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
         every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
         every { categoryService.getCategories(USER_ID) } returns listOf(CATEGORY)
 
-        val result = handle(UserCommand.PlainText(Buttons.EDIT_EXPENSE_CATEGORY))
+        val result = handle(UserCommand.SelectExpenseEditField(ExpenseEditField.Category))
 
         assertThat(
             result.response.outgoingMessages
@@ -115,7 +115,7 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
         every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
         every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
 
-        val result = handle(UserCommand.PlainText(Buttons.EDIT_EXPENSE_DATE))
+        val result = handle(UserCommand.SelectExpenseEditField(ExpenseEditField.Date))
 
         assertThat(
             result.response.outgoingMessages


### PR DESCRIPTION
## Что сделано

- Убрана зависимость handler-слоя от `adapter.ui.Buttons`: выбор даты и поля редактирования теперь приходит в handlers как доменные команды.
- Добавлены `ExpenseDateChoice`, `ExpenseEditField` и команды `SelectExpenseDate` / `SelectExpenseEditField`.
- Системные reply-тексты в рамках MVP считаются зарезервированными пользовательскими текстами.

## Пройденные проверки

- Unit-тесты
- Полный прогон тестов
