### PR TITLE
refactor: сузить payload выбора категорий

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/KeyboardApplier.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/KeyboardApplier.kt
@@ -17,7 +17,7 @@ class KeyboardApplier {
                 is BotAction.ShowMainMenu ->
                     sendMessage.replyMarkup = Keyboards.mainMenu()
                 is BotAction.ShowCategorySelection ->
-                    sendMessage.replyMarkup = Keyboards.categorySelection(action.categories)
+                    sendMessage.replyMarkup = Keyboards.categorySelection(action.categoryNames)
                 is BotAction.ShowExpenseDateSelection ->
                     sendMessage.replyMarkup = Keyboards.expenseDateSelection()
                 is BotAction.ShowCancel ->

--- a/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/Keyboards.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/adapter/ui/Keyboards.kt
@@ -1,7 +1,6 @@
 package me.kmozze.expensetracker.adapter.ui
 
 import me.kmozze.expensetracker.adapter.callback.CallbackData
-import me.kmozze.expensetracker.model.entity.Category
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.InlineKeyboardMarkup
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.ReplyKeyboardMarkup
 import org.telegram.telegrambots.meta.api.objects.replykeyboard.buttons.InlineKeyboardButton
@@ -26,12 +25,12 @@ object Keyboards {
             .build()
     }
 
-    fun categorySelection(categories: List<Category>): ReplyKeyboardMarkup {
+    fun categorySelection(categoryNames: List<String>): ReplyKeyboardMarkup {
         val rows =
-            categories
+            categoryNames
                 .chunked(2)
-                .map { categoriesChunk ->
-                    KeyboardRow(categoriesChunk.map { KeyboardButton(it.name) })
+                .map { categoryNamesChunk ->
+                    KeyboardRow(categoryNamesChunk.map { KeyboardButton(it) })
                 } +
                 listOf(cancelReplyRow())
 

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
@@ -126,7 +126,7 @@ class AwaitingCategorySelectionHandler(
                                         amount = currentState.expenseDraft.amount,
                                         description = currentState.expenseDraft.description,
                                     ),
-                                actions = listOf(BotAction.ShowCategorySelection(categories)),
+                                actions = listOf(BotAction.ShowCategorySelection(categories.map { it.name })),
                             ),
                         ),
                 ),
@@ -146,7 +146,7 @@ class AwaitingCategorySelectionHandler(
                         listOf(
                             OutgoingMessage(
                                 text = BotText.Error(errorCode),
-                                actions = listOf(BotAction.ShowCategorySelection(categories)),
+                                actions = listOf(BotAction.ShowCategorySelection(categories.map { it.name })),
                             ),
                         ),
                 ),

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseCategoryEditHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseCategoryEditHandler.kt
@@ -111,7 +111,7 @@ class AwaitingExpenseCategoryEditHandler(
                                         amount = expense.amount,
                                         description = expense.description,
                                     ),
-                                actions = listOf(BotAction.ShowCategorySelection(categories)),
+                                actions = listOf(BotAction.ShowCategorySelection(categories.map { it.name })),
                             ),
                         ),
                 ),
@@ -145,7 +145,7 @@ class AwaitingExpenseCategoryEditHandler(
                             listOf(
                                 OutgoingMessage(
                                     text = BotText.Error(BusinessErrorCode.CATEGORY_NOT_FOUND),
-                                    actions = listOf(BotAction.ShowCategorySelection(categories)),
+                                    actions = listOf(BotAction.ShowCategorySelection(categories.map { it.name })),
                                 ),
                             ),
                     ),

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseEditFieldSelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseEditFieldSelectionHandler.kt
@@ -124,7 +124,7 @@ class AwaitingExpenseEditFieldSelectionHandler(
                                         amount = expense.amount,
                                         description = expense.description,
                                     ),
-                                actions = listOf(BotAction.ShowCategorySelection(categories)),
+                                actions = listOf(BotAction.ShowCategorySelection(categories.map { it.name })),
                             ),
                         ),
                 ),

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseInputHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseInputHandler.kt
@@ -75,7 +75,7 @@ class AwaitingExpenseInputHandler(
                                         amount = expenseDraft.amount,
                                         description = expenseDraft.description,
                                     ),
-                                actions = listOf(BotAction.ShowCategorySelection(categories)),
+                                actions = listOf(BotAction.ShowCategorySelection(categories.map { it.name })),
                             ),
                         ),
                 ),

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/BotAction.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/BotAction.kt
@@ -1,13 +1,12 @@
 package me.kmozze.expensetracker.model.domain
 
-import me.kmozze.expensetracker.model.entity.Category
 import java.util.UUID
 
 sealed class BotAction {
     data object ShowMainMenu : BotAction()
 
     data class ShowCategorySelection(
-        val categories: List<Category>,
+        val categoryNames: List<String>,
     ) : BotAction()
 
     data object ShowExpenseDateSelection : BotAction()

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
@@ -14,6 +14,7 @@ import me.kmozze.expensetracker.model.domain.ResponseDelivery
 import me.kmozze.expensetracker.model.domain.UserState
 import me.kmozze.expensetracker.model.entity.Category
 import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.repository.ICategoryRepository
 import me.kmozze.expensetracker.repository.IExpenseRepository
 import me.kmozze.expensetracker.support.processUserInput
 import org.assertj.core.api.Assertions.assertThat
@@ -30,6 +31,9 @@ class AddExpenseFlowTest : AbstractFlowIntegrationTest() {
 
     @Autowired
     private lateinit var expenseRepository: IExpenseRepository
+
+    @Autowired
+    private lateinit var categoryRepository: ICategoryRepository
 
     @Autowired
     private lateinit var clock: Clock
@@ -443,11 +447,15 @@ class AddExpenseFlowTest : AbstractFlowIntegrationTest() {
             )
         val action = result.categorySelectionAction()
 
-        assertThat(action.categories).isNotEmpty()
+        assertThat(action.categoryNames).isNotEmpty()
+        val category =
+            categoryRepository
+                .findAllByUserId(userId)
+                .single { it.name == action.categoryNames.first() }
 
         return CategorySelection(
             result = result,
-            category = action.categories.first(),
+            category = category,
         )
     }
 

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
@@ -448,10 +448,13 @@ class AddExpenseFlowTest : AbstractFlowIntegrationTest() {
         val action = result.categorySelectionAction()
 
         assertThat(action.categoryNames).isNotEmpty()
+        val categories = categoryRepository.findAllByUserId(userId)
+        assertThat(action.categoryNames).containsExactlyElementsOf(categories.map { it.name })
+        val categoriesByName = categories.associateBy { it.name }
         val category =
-            categoryRepository
-                .findAllByUserId(userId)
-                .single { it.name == action.categoryNames.first() }
+            action.categoryNames
+                .map { categoriesByName.getValue(it) }
+                .first()
 
         return CategorySelection(
             result = result,

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/EditExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/EditExpenseFlowTest.kt
@@ -11,6 +11,7 @@ import me.kmozze.expensetracker.model.domain.ResponseDelivery
 import me.kmozze.expensetracker.model.domain.UserState
 import me.kmozze.expensetracker.model.entity.Category
 import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.repository.ICategoryRepository
 import me.kmozze.expensetracker.repository.IExpenseRepository
 import me.kmozze.expensetracker.support.processUserInput
 import org.assertj.core.api.Assertions.assertThat
@@ -27,6 +28,9 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
 
     @Autowired
     private lateinit var expenseRepository: IExpenseRepository
+
+    @Autowired
+    private lateinit var categoryRepository: ICategoryRepository
 
     @Test
     fun `edit expense from card updates amount category date and description`() {
@@ -103,7 +107,10 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
                 text = Buttons.EDIT_EXPENSE_CATEGORY,
             )
         val categorySelection = categorySelectionPrompt.categorySelectionAction()
-        val newCategory = categorySelection.categories.first { it.id != initialCategory.id }
+        val newCategory =
+            categoryRepository
+                .findAllByUserId(userId)
+                .single { it.name == categorySelection.categoryNames.first { categoryName -> categoryName != initialCategory.name } }
         val categoryUpdated =
             dialogueRouter.processUserInput(
                 userId = userId,
@@ -322,9 +329,13 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
             )
         val action = result.categorySelectionAction()
 
-        assertThat(action.categories).isNotEmpty()
+        assertThat(action.categoryNames).isNotEmpty()
+        val categories =
+            categoryRepository
+                .findAllByUserId(userId)
+                .filter { it.name in action.categoryNames }
 
-        return CategorySelection(result, action.categories)
+        return CategorySelection(result, categories)
     }
 
     private fun selectCategoryForDateSelection(

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/EditExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/EditExpenseFlowTest.kt
@@ -330,10 +330,12 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         val action = result.categorySelectionAction()
 
         assertThat(action.categoryNames).isNotEmpty()
+        val storedCategories = categoryRepository.findAllByUserId(userId)
+        assertThat(action.categoryNames).containsExactlyElementsOf(storedCategories.map { it.name })
+        val categoriesByName = storedCategories.associateBy { it.name }
         val categories =
-            categoryRepository
-                .findAllByUserId(userId)
-                .filter { it.name in action.categoryNames }
+            action.categoryNames
+                .map { categoriesByName.getValue(it) }
 
         return CategorySelection(result, categories)
     }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/ui/KeyboardApplierTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/ui/KeyboardApplierTest.kt
@@ -47,11 +47,11 @@ class KeyboardApplierTest {
     fun `send message uses reply keyboard for category names`() {
         val sendMessage = SendMessage("123", "text")
 
-        keyboardApplier.apply(sendMessage, listOf(BotAction.ShowCategorySelection(listOf("Еда", "Транспорт", "Жилье"))))
+        keyboardApplier.apply(sendMessage, listOf(BotAction.ShowCategorySelection(listOf("Еда", "Транспорт", "Жильё"))))
 
         val keyboard = sendMessage.replyMarkup as ReplyKeyboardMarkup
         assertThat(keyboard.keyboard[0].map { it.text }).containsExactly("Еда", "Транспорт")
-        assertThat(keyboard.keyboard[1].map { it.text }).containsExactly("Жилье")
+        assertThat(keyboard.keyboard[1].map { it.text }).containsExactly("Жильё")
     }
 
     @Test

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/ui/KeyboardApplierTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/adapter/ui/KeyboardApplierTest.kt
@@ -44,6 +44,17 @@ class KeyboardApplierTest {
     }
 
     @Test
+    fun `send message uses reply keyboard for category names`() {
+        val sendMessage = SendMessage("123", "text")
+
+        keyboardApplier.apply(sendMessage, listOf(BotAction.ShowCategorySelection(listOf("Еда", "Транспорт", "Жилье"))))
+
+        val keyboard = sendMessage.replyMarkup as ReplyKeyboardMarkup
+        assertThat(keyboard.keyboard[0].map { it.text }).containsExactly("Еда", "Транспорт")
+        assertThat(keyboard.keyboard[1].map { it.text }).containsExactly("Жилье")
+    }
+
+    @Test
     fun `send message uses reply keyboard for edit field selection`() {
         val sendMessage = SendMessage("123", "text")
 

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingCategorySelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingCategorySelectionHandlerTest.kt
@@ -86,7 +86,7 @@ class AwaitingCategorySelectionHandlerTest {
             result.response.outgoingMessages
                 .single()
                 .actions,
-        ).containsExactly(BotAction.ShowCategorySelection(categories))
+        ).containsExactly(BotAction.ShowCategorySelection(categories.map { it.name }))
         assertThat(result.nextState).isEqualTo(AWAITING_CATEGORY_SELECTION)
         verify(exactly = 1) { categoryService.getCategories(USER_ID) }
         confirmVerified(categoryService)
@@ -126,7 +126,7 @@ class AwaitingCategorySelectionHandlerTest {
             result.response.outgoingMessages
                 .single()
                 .actions,
-        ).containsExactly(BotAction.ShowCategorySelection(categories))
+        ).containsExactly(BotAction.ShowCategorySelection(categories.map { it.name }))
         assertThat(result.nextState).isEqualTo(AWAITING_CATEGORY_SELECTION)
         verify(exactly = 1) { categoryService.getCategories(USER_ID) }
         confirmVerified(categoryService)

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseCategoryEditHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseCategoryEditHandlerTest.kt
@@ -90,7 +90,7 @@ class AwaitingExpenseCategoryEditHandlerTest {
             result.response.outgoingMessages
                 .single()
                 .actions,
-        ).containsExactly(BotAction.ShowCategorySelection(categories))
+        ).containsExactly(BotAction.ShowCategorySelection(categories.map { it.name }))
         assertThat(result.nextState).isEqualTo(AWAITING_EXPENSE_CATEGORY_EDIT)
         verify(exactly = 1) { categoryService.getCategories(USER_ID) }
         confirmVerified(expenseService, categoryService)

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseEditFieldSelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseEditFieldSelectionHandlerTest.kt
@@ -102,7 +102,7 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
             result.response.outgoingMessages
                 .single()
                 .actions,
-        ).containsExactly(BotAction.ShowCategorySelection(listOf(CATEGORY)))
+        ).containsExactly(BotAction.ShowCategorySelection(listOf(CATEGORY.name)))
         assertThat(result.nextState)
             .isEqualTo(UserState.AwaitingExpenseCategoryEdit(expenseId = EXPENSE_ID))
         verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseInputHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseInputHandlerTest.kt
@@ -57,7 +57,7 @@ class AwaitingExpenseInputHandlerTest {
             result.response.outgoingMessages
                 .single()
                 .actions,
-        ).containsExactly(BotAction.ShowCategorySelection(categories))
+        ).containsExactly(BotAction.ShowCategorySelection(categories.map { it.name }))
         assertThat(result.nextState).isEqualTo(UserState.AwaitingCategorySelection(EXPENSE_DRAFT))
         verify(exactly = 1) { expenseService.parseExpense(EXPENSE_TEXT) }
         verify(exactly = 1) { categoryService.getCategories(USER_ID) }


### PR DESCRIPTION
## Что сделано

- BotAction.ShowCategorySelection теперь передает в UI только имена категорий вместо полных Category entity.
- Клавиатура выбора категорий строится из списка названий; handler-ы продолжают работать с Category внутри сценариев.
- Обновлены unit и flow-тесты под новый контракт.

## Пройденные проверки

- Полный прогон тестов.
- Ручное тестирование.