### PR TITLE
Вынести действия карточки расхода из IdleStateHandler

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/ExpenseCardActionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/ExpenseCardActionHandler.kt
@@ -1,0 +1,156 @@
+package me.kmozze.expensetracker.handler.statehandler
+
+import me.kmozze.expensetracker.handler.handlerResponse
+import me.kmozze.expensetracker.handler.outgoingMessage
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.HandlerResponse
+import me.kmozze.expensetracker.model.domain.ResponseDelivery
+import me.kmozze.expensetracker.model.domain.UserInput
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class ExpenseCardActionHandler(
+    private val expenseService: ExpenseService,
+    private val categoryService: CategoryService,
+) {
+    fun requestExpenseEdit(
+        input: UserInput,
+        expenseId: UUID,
+    ): HandlerResponse {
+        val expense =
+            expenseService.findExpenseForUser(
+                userId = input.userId,
+                expenseId = expenseId,
+            ) ?: return expenseUnavailableResult(input)
+
+        val category =
+            categoryService.findCategoryForUser(
+                categoryId = expense.categoryId,
+                userId = input.userId,
+            ) ?: return expenseUnavailableResult(input)
+
+        return handlerResponse(
+            messages =
+                listOf(
+                    outgoingMessage(
+                        text =
+                            expense.toExpenseView(category),
+                        actions = listOf(BotAction.ClearInlineKeyboard),
+                        delivery = input.callbackMessageDelivery(),
+                    ),
+                    outgoingMessage(
+                        text = BotText.EditExpenseFieldSelection,
+                        actions = listOf(BotAction.ShowExpenseEditFieldSelection),
+                    ),
+                ),
+            nextState = UserState.AwaitingExpenseEditFieldSelection(expense.id),
+        )
+    }
+
+    fun requestExpenseDeletion(
+        input: UserInput,
+        expenseId: UUID,
+    ): HandlerResponse =
+        expenseCardResult(
+            input = input,
+            expenseId = expenseId,
+            textFactory = { expense, category ->
+                expense.toExpenseView(category)
+            },
+            actionsFactory = { listOf(BotAction.ShowExpenseDeletionConfirmation(expenseId)) },
+        )
+
+    fun cancelExpenseDeletion(
+        input: UserInput,
+        expenseId: UUID,
+    ): HandlerResponse =
+        expenseCardResult(
+            input = input,
+            expenseId = expenseId,
+            textFactory = { expense, category ->
+                expense.toExpenseView(category)
+            },
+            actionsFactory = { listOf(BotAction.ShowExpenseCardActions(expenseId)) },
+        )
+
+    fun confirmExpenseDeletion(
+        input: UserInput,
+        expenseId: UUID,
+    ): HandlerResponse {
+        val deleted =
+            expenseService.deleteExpenseForUser(
+                userId = input.userId,
+                expenseId = expenseId,
+            )
+
+        return editExpenseCardResult(
+            input = input,
+            text =
+                if (deleted) {
+                    BotText.ExpenseDeleted
+                } else {
+                    BotText.ExpenseUnavailable
+                },
+            actions = listOf(BotAction.ClearInlineKeyboard),
+        )
+    }
+
+    private fun expenseCardResult(
+        input: UserInput,
+        expenseId: UUID,
+        textFactory: (Expense, Category) -> BotText,
+        actionsFactory: () -> List<BotAction>,
+    ): HandlerResponse {
+        val expense =
+            expenseService.findExpenseForUser(
+                userId = input.userId,
+                expenseId = expenseId,
+            ) ?: return expenseUnavailableResult(input)
+
+        val category =
+            categoryService.findCategoryForUser(
+                categoryId = expense.categoryId,
+                userId = input.userId,
+            ) ?: return expenseUnavailableResult(input)
+
+        return editExpenseCardResult(
+            input = input,
+            text = textFactory(expense, category),
+            actions = actionsFactory(),
+        )
+    }
+
+    private fun expenseUnavailableResult(input: UserInput): HandlerResponse =
+        editExpenseCardResult(
+            input = input,
+            text = BotText.ExpenseUnavailable,
+            actions = listOf(BotAction.ClearInlineKeyboard),
+        )
+
+    private fun editExpenseCardResult(
+        input: UserInput,
+        text: BotText,
+        actions: List<BotAction>,
+    ): HandlerResponse =
+        handlerResponse(
+            message =
+                outgoingMessage(
+                    text = text,
+                    actions = actions,
+                    delivery = input.callbackMessageDelivery(),
+                ),
+            nextState = UserState.Idle,
+        )
+
+    private fun UserInput.callbackMessageDelivery(): ResponseDelivery =
+        callbackMessageId
+            ?.let { ResponseDelivery.EditMessage(it) }
+            ?: ResponseDelivery.SendNewMessage
+}

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/IdleStateHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/IdleStateHandler.kt
@@ -5,22 +5,15 @@ import me.kmozze.expensetracker.handler.outgoingMessage
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.HandlerResponse
-import me.kmozze.expensetracker.model.domain.ResponseDelivery
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserInput
 import me.kmozze.expensetracker.model.domain.UserState
-import me.kmozze.expensetracker.model.entity.Category
-import me.kmozze.expensetracker.model.entity.Expense
-import me.kmozze.expensetracker.service.CategoryService
-import me.kmozze.expensetracker.service.ExpenseService
 import org.springframework.stereotype.Component
-import java.util.UUID
 import kotlin.reflect.KClass
 
 @Component
 class IdleStateHandler(
-    private val expenseService: ExpenseService,
-    private val categoryService: CategoryService,
+    private val expenseCardActionHandler: ExpenseCardActionHandler,
 ) : StateHandler {
     override val supportedStateClass: KClass<out UserState> = UserState.Idle::class
 
@@ -57,16 +50,16 @@ class IdleStateHandler(
                 )
 
             is UserCommand.RequestExpenseEdit ->
-                requestExpenseEdit(input, command.expenseId)
+                expenseCardActionHandler.requestExpenseEdit(input, command.expenseId)
 
             is UserCommand.RequestExpenseDeletion ->
-                requestExpenseDeletion(input, command.expenseId)
+                expenseCardActionHandler.requestExpenseDeletion(input, command.expenseId)
 
             is UserCommand.ConfirmExpenseDeletion ->
-                confirmExpenseDeletion(input, command.expenseId)
+                expenseCardActionHandler.confirmExpenseDeletion(input, command.expenseId)
 
             is UserCommand.CancelExpenseDeletion ->
-                cancelExpenseDeletion(input, command.expenseId)
+                expenseCardActionHandler.cancelExpenseDeletion(input, command.expenseId)
 
             UserCommand.Cancel,
             UserCommand.InvalidExpenseAction,
@@ -91,138 +84,4 @@ class IdleStateHandler(
                 )
         }
     }
-
-    private fun requestExpenseEdit(
-        input: UserInput,
-        expenseId: UUID,
-    ): HandlerResponse {
-        val expense =
-            expenseService.findExpenseForUser(
-                userId = input.userId,
-                expenseId = expenseId,
-            ) ?: return expenseUnavailableResult(input)
-
-        val category =
-            categoryService.findCategoryForUser(
-                categoryId = expense.categoryId,
-                userId = input.userId,
-            ) ?: return expenseUnavailableResult(input)
-
-        return handlerResponse(
-            messages =
-                listOf(
-                    outgoingMessage(
-                        text =
-                            expense.toExpenseView(category),
-                        actions = listOf(BotAction.ClearInlineKeyboard),
-                        delivery = input.callbackMessageDelivery(),
-                    ),
-                    outgoingMessage(
-                        text = BotText.EditExpenseFieldSelection,
-                        actions = listOf(BotAction.ShowExpenseEditFieldSelection),
-                    ),
-                ),
-            nextState = UserState.AwaitingExpenseEditFieldSelection(expense.id),
-        )
-    }
-
-    private fun requestExpenseDeletion(
-        input: UserInput,
-        expenseId: UUID,
-    ): HandlerResponse =
-        expenseCardResult(
-            input = input,
-            expenseId = expenseId,
-            textFactory = { expense, category ->
-                expense.toExpenseView(category)
-            },
-            actionsFactory = { listOf(BotAction.ShowExpenseDeletionConfirmation(expenseId)) },
-        )
-
-    private fun cancelExpenseDeletion(
-        input: UserInput,
-        expenseId: UUID,
-    ): HandlerResponse =
-        expenseCardResult(
-            input = input,
-            expenseId = expenseId,
-            textFactory = { expense, category ->
-                expense.toExpenseView(category)
-            },
-            actionsFactory = { listOf(BotAction.ShowExpenseCardActions(expenseId)) },
-        )
-
-    private fun confirmExpenseDeletion(
-        input: UserInput,
-        expenseId: UUID,
-    ): HandlerResponse {
-        val deleted =
-            expenseService.deleteExpenseForUser(
-                userId = input.userId,
-                expenseId = expenseId,
-            )
-
-        return editExpenseCardResult(
-            input = input,
-            text =
-                if (deleted) {
-                    BotText.ExpenseDeleted
-                } else {
-                    BotText.ExpenseUnavailable
-                },
-            actions = listOf(BotAction.ClearInlineKeyboard),
-        )
-    }
-
-    private fun expenseCardResult(
-        input: UserInput,
-        expenseId: UUID,
-        textFactory: (Expense, Category) -> BotText,
-        actionsFactory: () -> List<BotAction>,
-    ): HandlerResponse {
-        val expense =
-            expenseService.findExpenseForUser(
-                userId = input.userId,
-                expenseId = expenseId,
-            ) ?: return expenseUnavailableResult(input)
-
-        val category =
-            categoryService.findCategoryForUser(
-                categoryId = expense.categoryId,
-                userId = input.userId,
-            ) ?: return expenseUnavailableResult(input)
-
-        return editExpenseCardResult(
-            input = input,
-            text = textFactory(expense, category),
-            actions = actionsFactory(),
-        )
-    }
-
-    private fun expenseUnavailableResult(input: UserInput): HandlerResponse =
-        editExpenseCardResult(
-            input = input,
-            text = BotText.ExpenseUnavailable,
-            actions = listOf(BotAction.ClearInlineKeyboard),
-        )
-
-    private fun editExpenseCardResult(
-        input: UserInput,
-        text: BotText,
-        actions: List<BotAction>,
-    ): HandlerResponse =
-        handlerResponse(
-            message =
-                outgoingMessage(
-                    text = text,
-                    actions = actions,
-                    delivery = input.callbackMessageDelivery(),
-                ),
-            nextState = UserState.Idle,
-        )
-
-    private fun UserInput.callbackMessageDelivery(): ResponseDelivery =
-        callbackMessageId
-            ?.let { ResponseDelivery.EditMessage(it) }
-            ?: ResponseDelivery.SendNewMessage
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/ExpenseCardActionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/ExpenseCardActionHandlerTest.kt
@@ -1,0 +1,401 @@
+package me.kmozze.expensetracker.unit.handler.statehandler
+
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.verify
+import me.kmozze.expensetracker.handler.statehandler.ExpenseCardActionHandler
+import me.kmozze.expensetracker.model.domain.BotAction
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.HandlerResponse
+import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.ResponseDelivery
+import me.kmozze.expensetracker.model.domain.UserCommand
+import me.kmozze.expensetracker.model.domain.UserInput
+import me.kmozze.expensetracker.model.domain.UserState
+import me.kmozze.expensetracker.model.entity.Category
+import me.kmozze.expensetracker.model.entity.Expense
+import me.kmozze.expensetracker.service.CategoryService
+import me.kmozze.expensetracker.service.ExpenseService
+import me.kmozze.expensetracker.support.makeUserInput
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.util.UUID
+
+@ExtendWith(MockKExtension::class)
+class ExpenseCardActionHandlerTest {
+    private val expenseService: ExpenseService = mockk()
+    private val categoryService: CategoryService = mockk()
+    private lateinit var handler: ExpenseCardActionHandler
+
+    @BeforeEach
+    fun setUp() {
+        handler =
+            ExpenseCardActionHandler(
+                expenseService = expenseService,
+                categoryService = categoryService,
+            )
+    }
+
+    @Test
+    fun `request expense deletion edits card into deletion confirmation`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result =
+            handler.requestExpenseDeletion(
+                input = makeInput(UserCommand.RequestExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = EXPENSE_VIEW,
+            actions = listOf(BotAction.ShowExpenseDeletionConfirmation(EXPENSE_ID)),
+            delivery = ResponseDelivery.EditMessage(MESSAGE_ID),
+            nextState = UserState.Idle,
+        )
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+    }
+
+    @Test
+    fun `request expense deletion sends a new message without callback message id`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result =
+            handler.requestExpenseDeletion(
+                input = makeInput(UserCommand.RequestExpenseDeletion(EXPENSE_ID)),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = EXPENSE_VIEW,
+            actions = listOf(BotAction.ShowExpenseDeletionConfirmation(EXPENSE_ID)),
+            delivery = ResponseDelivery.SendNewMessage,
+            nextState = UserState.Idle,
+        )
+    }
+
+    @Test
+    fun `request expense deletion returns unavailable when expense is missing`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns null
+
+        val result =
+            handler.requestExpenseDeletion(
+                input = makeInput(UserCommand.RequestExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = BotText.ExpenseUnavailable,
+            actions = listOf(BotAction.ClearInlineKeyboard),
+            delivery = ResponseDelivery.EditMessage(MESSAGE_ID),
+            nextState = UserState.Idle,
+        )
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+    }
+
+    @Test
+    fun `request expense deletion returns unavailable when category is missing`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns null
+
+        val result =
+            handler.requestExpenseDeletion(
+                input = makeInput(UserCommand.RequestExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = BotText.ExpenseUnavailable,
+            actions = listOf(BotAction.ClearInlineKeyboard),
+            delivery = ResponseDelivery.EditMessage(MESSAGE_ID),
+            nextState = UserState.Idle,
+        )
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+    }
+
+    @Test
+    fun `request expense edit opens field selection`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result =
+            handler.requestExpenseEdit(
+                input = makeInput(UserCommand.RequestExpenseEdit(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertThat(result.outgoingMessages).hasSize(2)
+        assertThat(result.outgoingMessages[0].text).isEqualTo(EXPENSE_VIEW)
+        assertThat(result.outgoingMessages[0].actions).containsExactly(BotAction.ClearInlineKeyboard)
+        assertThat(result.outgoingMessages[0].delivery).isEqualTo(ResponseDelivery.EditMessage(MESSAGE_ID))
+        assertThat(result.outgoingMessages[1].text).isEqualTo(BotText.EditExpenseFieldSelection)
+        assertThat(result.outgoingMessages[1].actions).containsExactly(BotAction.ShowExpenseEditFieldSelection)
+        assertThat(result.outgoingMessages[1].delivery).isEqualTo(ResponseDelivery.SendNewMessage)
+        assertThat(result.nextState)
+            .isEqualTo(UserState.AwaitingExpenseEditFieldSelection(expenseId = EXPENSE_ID))
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+    }
+
+    @Test
+    fun `request expense edit sends a new card message without callback message id`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result =
+            handler.requestExpenseEdit(
+                input = makeInput(UserCommand.RequestExpenseEdit(EXPENSE_ID)),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertThat(result.outgoingMessages[0].delivery).isEqualTo(ResponseDelivery.SendNewMessage)
+        assertThat(result.nextState)
+            .isEqualTo(UserState.AwaitingExpenseEditFieldSelection(expenseId = EXPENSE_ID))
+    }
+
+    @Test
+    fun `request expense edit returns unavailable when expense is missing`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns null
+
+        val result =
+            handler.requestExpenseEdit(
+                input = makeInput(UserCommand.RequestExpenseEdit(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = BotText.ExpenseUnavailable,
+            actions = listOf(BotAction.ClearInlineKeyboard),
+            delivery = ResponseDelivery.EditMessage(MESSAGE_ID),
+            nextState = UserState.Idle,
+        )
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+    }
+
+    @Test
+    fun `request expense edit returns unavailable when category is missing`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns null
+
+        val result =
+            handler.requestExpenseEdit(
+                input = makeInput(UserCommand.RequestExpenseEdit(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = BotText.ExpenseUnavailable,
+            actions = listOf(BotAction.ClearInlineKeyboard),
+            delivery = ResponseDelivery.EditMessage(MESSAGE_ID),
+            nextState = UserState.Idle,
+        )
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+    }
+
+    @Test
+    fun `cancel expense deletion restores card actions`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result =
+            handler.cancelExpenseDeletion(
+                input = makeInput(UserCommand.CancelExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = EXPENSE_VIEW,
+            actions = listOf(BotAction.ShowExpenseCardActions(EXPENSE_ID)),
+            delivery = ResponseDelivery.EditMessage(MESSAGE_ID),
+            nextState = UserState.Idle,
+        )
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+    }
+
+    @Test
+    fun `cancel expense deletion returns unavailable when expense is missing`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns null
+
+        val result =
+            handler.cancelExpenseDeletion(
+                input = makeInput(UserCommand.CancelExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = BotText.ExpenseUnavailable,
+            actions = listOf(BotAction.ClearInlineKeyboard),
+            delivery = ResponseDelivery.EditMessage(MESSAGE_ID),
+            nextState = UserState.Idle,
+        )
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+    }
+
+    @Test
+    fun `cancel expense deletion returns unavailable when category is missing`() {
+        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns null
+
+        val result =
+            handler.cancelExpenseDeletion(
+                input = makeInput(UserCommand.CancelExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = BotText.ExpenseUnavailable,
+            actions = listOf(BotAction.ClearInlineKeyboard),
+            delivery = ResponseDelivery.EditMessage(MESSAGE_ID),
+            nextState = UserState.Idle,
+        )
+        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+    }
+
+    @Test
+    fun `confirm expense deletion deletes expense and clears inline keyboard`() {
+        every { expenseService.deleteExpenseForUser(USER_ID, EXPENSE_ID) } returns true
+
+        val result =
+            handler.confirmExpenseDeletion(
+                input = makeInput(UserCommand.ConfirmExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = BotText.ExpenseDeleted,
+            actions = listOf(BotAction.ClearInlineKeyboard),
+            delivery = ResponseDelivery.EditMessage(MESSAGE_ID),
+            nextState = UserState.Idle,
+        )
+        verify(exactly = 1) { expenseService.deleteExpenseForUser(USER_ID, EXPENSE_ID) }
+    }
+
+    @Test
+    fun `confirm expense deletion returns unavailable when expense was not deleted`() {
+        every { expenseService.deleteExpenseForUser(USER_ID, EXPENSE_ID) } returns false
+
+        val result =
+            handler.confirmExpenseDeletion(
+                input = makeInput(UserCommand.ConfirmExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = BotText.ExpenseUnavailable,
+            actions = listOf(BotAction.ClearInlineKeyboard),
+            delivery = ResponseDelivery.EditMessage(MESSAGE_ID),
+            nextState = UserState.Idle,
+        )
+        verify(exactly = 1) { expenseService.deleteExpenseForUser(USER_ID, EXPENSE_ID) }
+    }
+
+    @Test
+    fun `confirm expense deletion sends a new message without callback message id`() {
+        every { expenseService.deleteExpenseForUser(USER_ID, EXPENSE_ID) } returns true
+
+        val result =
+            handler.confirmExpenseDeletion(
+                input = makeInput(UserCommand.ConfirmExpenseDeletion(EXPENSE_ID)),
+                expenseId = EXPENSE_ID,
+            )
+
+        assertSingleMessage(
+            result = result,
+            text = BotText.ExpenseDeleted,
+            actions = listOf(BotAction.ClearInlineKeyboard),
+            delivery = ResponseDelivery.SendNewMessage,
+            nextState = UserState.Idle,
+        )
+    }
+
+    private fun assertSingleMessage(
+        result: HandlerResponse,
+        text: BotText,
+        actions: List<BotAction>,
+        delivery: ResponseDelivery,
+        nextState: UserState,
+    ) {
+        assertThat(
+            result.outgoingMessages
+                .single()
+                .text,
+        ).isEqualTo(text)
+        assertThat(
+            result.outgoingMessages
+                .single()
+                .actions,
+        ).containsExactlyElementsOf(actions)
+        assertThat(
+            result.outgoingMessages
+                .single()
+                .delivery,
+        ).isEqualTo(delivery)
+        assertThat(result.nextState).isEqualTo(nextState)
+    }
+
+    private fun makeInput(
+        command: UserCommand,
+        callbackMessageId: Int? = null,
+    ): UserInput =
+        makeUserInput(
+            userId = USER_ID,
+            chatId = CHAT_ID,
+            callbackMessageId = callbackMessageId,
+            command = command,
+        )
+
+    private companion object {
+        const val USER_ID = 123L
+        const val CHAT_ID = 456L
+        const val MESSAGE_ID = 789
+        const val EXPENSE_DESCRIPTION = "такси"
+        val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
+        val EXPENSE_DATE: LocalDate = LocalDate.parse("2026-05-24")
+        val CATEGORY: Category =
+            Category(
+                id = CATEGORY_ID,
+                name = "Транспорт",
+                userId = USER_ID,
+            )
+        val EXPENSE: Expense =
+            Expense(
+                id = EXPENSE_ID,
+                categoryId = CATEGORY_ID,
+                amount = EXPENSE_AMOUNT,
+                userId = USER_ID,
+                expenseDate = EXPENSE_DATE,
+                description = EXPENSE_DESCRIPTION,
+            )
+        val EXPENSE_VIEW: BotText.ExpenseView =
+            BotText.ExpenseView(
+                amount = EXPENSE_AMOUNT,
+                categoryName = CATEGORY.name,
+                expenseDate = EXPENSE_DATE,
+                description = EXPENSE_DESCRIPTION,
+            )
+    }
+}

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/IdleStateHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/IdleStateHandlerTest.kt
@@ -4,18 +4,16 @@ import io.mockk.every
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.verify
+import me.kmozze.expensetracker.handler.statehandler.ExpenseCardActionHandler
 import me.kmozze.expensetracker.handler.statehandler.IdleStateHandler
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
-import me.kmozze.expensetracker.model.domain.Money
+import me.kmozze.expensetracker.model.domain.HandlerResponse
+import me.kmozze.expensetracker.model.domain.OutgoingMessage
 import me.kmozze.expensetracker.model.domain.ResponseDelivery
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserInput
 import me.kmozze.expensetracker.model.domain.UserState
-import me.kmozze.expensetracker.model.entity.Category
-import me.kmozze.expensetracker.model.entity.Expense
-import me.kmozze.expensetracker.service.CategoryService
-import me.kmozze.expensetracker.service.ExpenseService
 import me.kmozze.expensetracker.support.makeUserInput
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -23,23 +21,19 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import java.math.BigDecimal
-import java.time.LocalDate
 import java.util.UUID
 import java.util.stream.Stream
 
 @ExtendWith(MockKExtension::class)
 class IdleStateHandlerTest {
-    private val expenseService: ExpenseService = mockk()
-    private val categoryService: CategoryService = mockk()
+    private val expenseCardActionHandler: ExpenseCardActionHandler = mockk()
     private lateinit var handler: IdleStateHandler
 
     @BeforeEach
     fun setUp() {
         handler =
             IdleStateHandler(
-                expenseService = expenseService,
-                categoryService = categoryService,
+                expenseCardActionHandler = expenseCardActionHandler,
             )
     }
 
@@ -131,267 +125,87 @@ class IdleStateHandlerTest {
     }
 
     @Test
-    fun `request expense deletion edits card into deletion confirmation`() {
-        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
-        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+    fun `request expense edit is delegated to expense card action handler`() {
+        val input = makeInput(UserCommand.RequestExpenseEdit(EXPENSE_ID))
+        every { expenseCardActionHandler.requestExpenseEdit(input, EXPENSE_ID) } returns DELEGATE_RESPONSE
 
         val result =
             handler.handle(
-                input = makeInput(UserCommand.RequestExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                input = input,
                 currentState = UserState.Idle,
             )
 
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .text,
-        ).isEqualTo(
-            EXPENSE_VIEW,
-        )
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .actions,
-        ).containsExactly(BotAction.ShowExpenseDeletionConfirmation(EXPENSE_ID))
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .delivery,
-        ).isEqualTo(ResponseDelivery.EditMessage(MESSAGE_ID))
-        assertThat(result.nextState).isEqualTo(UserState.Idle)
-        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
-        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        assertThat(result).isSameAs(DELEGATE_RESPONSE)
+        verify(exactly = 1) { expenseCardActionHandler.requestExpenseEdit(input, EXPENSE_ID) }
     }
 
     @Test
-    fun `request expense edit opens field selection`() {
-        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
-        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+    fun `request expense deletion is delegated to expense card action handler`() {
+        val input = makeInput(UserCommand.RequestExpenseDeletion(EXPENSE_ID))
+        every { expenseCardActionHandler.requestExpenseDeletion(input, EXPENSE_ID) } returns DELEGATE_RESPONSE
 
         val result =
             handler.handle(
-                input = makeInput(UserCommand.RequestExpenseEdit(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                input = input,
                 currentState = UserState.Idle,
             )
 
-        assertThat(
-            result.outgoingMessages[0]
-                .text,
-        ).isEqualTo(
-            EXPENSE_VIEW,
-        )
-        assertThat(
-            result.outgoingMessages[0]
-                .actions,
-        ).containsExactly(BotAction.ClearInlineKeyboard)
-        assertThat(
-            result.outgoingMessages[0]
-                .delivery,
-        ).isEqualTo(ResponseDelivery.EditMessage(MESSAGE_ID))
-        assertThat(
-            result.outgoingMessages[1]
-                .text,
-        ).isEqualTo(BotText.EditExpenseFieldSelection)
-        assertThat(
-            result.outgoingMessages[1]
-                .actions,
-        ).containsExactly(BotAction.ShowExpenseEditFieldSelection)
-        assertThat(result.nextState)
-            .isEqualTo(UserState.AwaitingExpenseEditFieldSelection(expenseId = EXPENSE_ID))
-        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
-        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        assertThat(result).isSameAs(DELEGATE_RESPONSE)
+        verify(exactly = 1) { expenseCardActionHandler.requestExpenseDeletion(input, EXPENSE_ID) }
     }
 
     @Test
-    fun `request expense edit returns unavailable when expense is missing`() {
-        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns null
+    fun `confirm expense deletion is delegated to expense card action handler`() {
+        val input = makeInput(UserCommand.ConfirmExpenseDeletion(EXPENSE_ID))
+        every { expenseCardActionHandler.confirmExpenseDeletion(input, EXPENSE_ID) } returns DELEGATE_RESPONSE
 
         val result =
             handler.handle(
-                input = makeInput(UserCommand.RequestExpenseEdit(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                input = input,
                 currentState = UserState.Idle,
             )
 
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .text,
-        ).isEqualTo(BotText.ExpenseUnavailable)
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .actions,
-        ).containsExactly(BotAction.ClearInlineKeyboard)
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .delivery,
-        ).isEqualTo(ResponseDelivery.EditMessage(MESSAGE_ID))
-        assertThat(result.nextState).isEqualTo(UserState.Idle)
-        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        assertThat(result).isSameAs(DELEGATE_RESPONSE)
+        verify(exactly = 1) { expenseCardActionHandler.confirmExpenseDeletion(input, EXPENSE_ID) }
     }
 
     @Test
-    fun `cancel expense deletion restores card actions`() {
-        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns EXPENSE
-        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+    fun `cancel expense deletion is delegated to expense card action handler`() {
+        val input = makeInput(UserCommand.CancelExpenseDeletion(EXPENSE_ID))
+        every { expenseCardActionHandler.cancelExpenseDeletion(input, EXPENSE_ID) } returns DELEGATE_RESPONSE
 
         val result =
             handler.handle(
-                input = makeInput(UserCommand.CancelExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
+                input = input,
                 currentState = UserState.Idle,
             )
 
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .text,
-        ).isEqualTo(
-            EXPENSE_VIEW,
-        )
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .actions,
-        ).containsExactly(BotAction.ShowExpenseCardActions(EXPENSE_ID))
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .delivery,
-        ).isEqualTo(ResponseDelivery.EditMessage(MESSAGE_ID))
-        assertThat(result.nextState).isEqualTo(UserState.Idle)
-        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
-        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        assertThat(result).isSameAs(DELEGATE_RESPONSE)
+        verify(exactly = 1) { expenseCardActionHandler.cancelExpenseDeletion(input, EXPENSE_ID) }
     }
 
-    @Test
-    fun `confirm expense deletion deletes expense and clears inline keyboard`() {
-        every { expenseService.deleteExpenseForUser(USER_ID, EXPENSE_ID) } returns true
-
-        val result =
-            handler.handle(
-                input = makeInput(UserCommand.ConfirmExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
-                currentState = UserState.Idle,
-            )
-
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .text,
-        ).isEqualTo(BotText.ExpenseDeleted)
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .actions,
-        ).containsExactly(BotAction.ClearInlineKeyboard)
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .delivery,
-        ).isEqualTo(ResponseDelivery.EditMessage(MESSAGE_ID))
-        assertThat(result.nextState).isEqualTo(UserState.Idle)
-        verify(exactly = 1) { expenseService.deleteExpenseForUser(USER_ID, EXPENSE_ID) }
-    }
-
-    @Test
-    fun `request expense deletion returns unavailable when expense is missing`() {
-        every { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) } returns null
-
-        val result =
-            handler.handle(
-                input = makeInput(UserCommand.RequestExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
-                currentState = UserState.Idle,
-            )
-
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .text,
-        ).isEqualTo(BotText.ExpenseUnavailable)
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .actions,
-        ).containsExactly(BotAction.ClearInlineKeyboard)
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .delivery,
-        ).isEqualTo(ResponseDelivery.EditMessage(MESSAGE_ID))
-        assertThat(result.nextState).isEqualTo(UserState.Idle)
-        verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
-    }
-
-    @Test
-    fun `confirm expense deletion returns unavailable when expense was not deleted`() {
-        every { expenseService.deleteExpenseForUser(USER_ID, EXPENSE_ID) } returns false
-
-        val result =
-            handler.handle(
-                input = makeInput(UserCommand.ConfirmExpenseDeletion(EXPENSE_ID), callbackMessageId = MESSAGE_ID),
-                currentState = UserState.Idle,
-            )
-
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .text,
-        ).isEqualTo(BotText.ExpenseUnavailable)
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .actions,
-        ).containsExactly(BotAction.ClearInlineKeyboard)
-        assertThat(
-            result.outgoingMessages
-                .single()
-                .delivery,
-        ).isEqualTo(ResponseDelivery.EditMessage(MESSAGE_ID))
-        assertThat(result.nextState).isEqualTo(UserState.Idle)
-        verify(exactly = 1) { expenseService.deleteExpenseForUser(USER_ID, EXPENSE_ID) }
-    }
-
-    private fun makeInput(
-        command: UserCommand,
-        callbackMessageId: Int? = null,
-    ): UserInput =
+    private fun makeInput(command: UserCommand): UserInput =
         makeUserInput(
             userId = USER_ID,
             chatId = CHAT_ID,
-            callbackMessageId = callbackMessageId,
             command = command,
         )
 
     private companion object {
         const val USER_ID = 123L
         const val CHAT_ID = 456L
-        const val MESSAGE_ID = 789
-        const val EXPENSE_DESCRIPTION = "такси"
         val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
-        val CATEGORY_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
-        val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
-        val EXPENSE_DATE: LocalDate = LocalDate.parse("2026-05-24")
-        val CATEGORY: Category =
-            Category(
-                id = CATEGORY_ID,
-                name = "Транспорт",
-                userId = USER_ID,
-            )
-        val EXPENSE: Expense =
-            Expense(
-                id = EXPENSE_ID,
-                categoryId = CATEGORY_ID,
-                amount = EXPENSE_AMOUNT,
-                userId = USER_ID,
-                expenseDate = EXPENSE_DATE,
-                description = EXPENSE_DESCRIPTION,
-            )
-        val EXPENSE_VIEW: BotText.ExpenseView =
-            BotText.ExpenseView(
-                amount = EXPENSE_AMOUNT,
-                categoryName = CATEGORY.name,
-                expenseDate = EXPENSE_DATE,
-                description = EXPENSE_DESCRIPTION,
+        val DELEGATE_RESPONSE: HandlerResponse =
+            HandlerResponse(
+                outgoingMessages =
+                    listOf(
+                        OutgoingMessage(
+                            text = BotText.Done,
+                            actions = emptyList(),
+                            delivery = ResponseDelivery.SendNewMessage,
+                        ),
+                    ),
+                nextState = UserState.Idle,
             )
 
         @JvmStatic


### PR DESCRIPTION
## Что сделано
- Вынесена обработка inline-действий карточки расхода в отдельный `ExpenseCardActionHandler`.
- `IdleStateHandler` оставлен для idle-меню, fallback-веток и делегирования карточных команд.
- Закрывается tech debt про рост `IdleStateHandler` при добавлении карточных действий. Источники: PR #42 review round 1; PR #57 approve review.

## Пройденные проверки
- Unit-проверки пройдены.
- Полный прогон тестов пройден.