### PR TITLE
refactor: consolidate expense draft session state

### DIFF
--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingCategorySelectionHandler.kt
@@ -5,6 +5,7 @@ import me.kmozze.expensetracker.handler.handlerResponse
 import me.kmozze.expensetracker.handler.outgoingMessage
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserInput
@@ -69,13 +70,16 @@ class AwaitingCategorySelectionHandler(
                     errorCode = BusinessErrorCode.CATEGORY_NOT_FOUND,
                 )
 
-        val expenseDraft = currentState.expenseDraft.copy(categoryId = category.id)
+        val expenseDraft =
+            currentState.expenseDraft.copy(
+                category = ExpenseDraftCategory(categoryId = category.id, name = category.name),
+            )
 
         return handlerResponse(
             messages =
                 listOf(
                     outgoingMessage(
-                        text = expenseDraft.toExpenseView(categoryName = category.name),
+                        text = expenseDraft.toExpenseView(),
                         actions = emptyList(),
                     ),
                     outgoingMessage(
@@ -86,7 +90,6 @@ class AwaitingCategorySelectionHandler(
             nextState =
                 UserState.AwaitingExpenseDateSelection(
                     expenseDraft = expenseDraft,
-                    categoryName = category.name,
                 ),
         )
     }

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseAmountEditHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseAmountEditHandler.kt
@@ -35,7 +35,7 @@ class AwaitingExpenseAmountEditHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
+                    expenseId = currentState.editSession.expenseId,
                 )
 
             UserCommand.FinishExpenseEdit ->
@@ -43,8 +43,7 @@ class AwaitingExpenseAmountEditHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
-                    expenseDraft = currentState.expenseDraft,
+                    editSession = currentState.editSession,
                 )
 
             is UserCommand.PlainText -> saveAmount(currentState, command.value)
@@ -71,9 +70,10 @@ class AwaitingExpenseAmountEditHandler(
             }
 
         return buildDraftExpenseEditFieldSelectionResult(
-            expenseId = currentState.expenseId,
-            expenseDraft = currentState.expenseDraft.copy(amount = amount),
-            categoryName = currentState.categoryName,
+            editSession =
+                currentState.editSession.withExpenseDraft(
+                    currentState.editSession.expenseDraft.copy(amount = amount),
+                ),
         )
     }
 

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseCategoryEditHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseCategoryEditHandler.kt
@@ -5,6 +5,7 @@ import me.kmozze.expensetracker.handler.handlerResponse
 import me.kmozze.expensetracker.handler.outgoingMessage
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserInput
@@ -36,7 +37,7 @@ class AwaitingExpenseCategoryEditHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
+                    expenseId = currentState.editSession.expenseId,
                 )
 
             UserCommand.FinishExpenseEdit ->
@@ -44,8 +45,7 @@ class AwaitingExpenseCategoryEditHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
-                    expenseDraft = currentState.expenseDraft,
+                    editSession = currentState.editSession,
                 )
 
             is UserCommand.PlainText -> selectCategory(input, currentState, command.value)
@@ -67,9 +67,12 @@ class AwaitingExpenseCategoryEditHandler(
                 )
 
         return buildDraftExpenseEditFieldSelectionResult(
-            expenseId = currentState.expenseId,
-            expenseDraft = currentState.expenseDraft.copy(categoryId = category.id),
-            categoryName = category.name,
+            editSession =
+                currentState.editSession.withExpenseDraft(
+                    currentState.editSession.expenseDraft.copy(
+                        category = ExpenseDraftCategory(categoryId = category.id, name = category.name),
+                    ),
+                ),
         )
     }
 
@@ -94,7 +97,7 @@ class AwaitingExpenseCategoryEditHandler(
             messages =
                 listOf(
                     outgoingMessage(
-                        text = currentState.expenseDraft.toExpenseView(categoryName = currentState.categoryName),
+                        text = currentState.editSession.expenseDraft.toExpenseView(),
                         actions = emptyList(),
                     ),
                     outgoingMessage(

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDateEditManualInputHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDateEditManualInputHandler.kt
@@ -35,7 +35,7 @@ class AwaitingExpenseDateEditManualInputHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
+                    expenseId = currentState.editSession.expenseId,
                 )
 
             UserCommand.FinishExpenseEdit ->
@@ -43,8 +43,7 @@ class AwaitingExpenseDateEditManualInputHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
-                    expenseDraft = currentState.expenseDraft,
+                    editSession = currentState.editSession,
                 )
 
             is UserCommand.PlainText -> updateDate(currentState, command.value)
@@ -71,9 +70,10 @@ class AwaitingExpenseDateEditManualInputHandler(
             }
 
         return buildDraftExpenseEditFieldSelectionResult(
-            expenseId = currentState.expenseId,
-            expenseDraft = currentState.expenseDraft.copy(expenseDate = expenseDate),
-            categoryName = currentState.categoryName,
+            editSession =
+                currentState.editSession.withExpenseDraft(
+                    currentState.editSession.expenseDraft.copy(expenseDate = expenseDate),
+                ),
         )
     }
 
@@ -82,7 +82,7 @@ class AwaitingExpenseDateEditManualInputHandler(
             messages =
                 listOf(
                     outgoingMessage(
-                        text = currentState.expenseDraft.toExpenseView(categoryName = currentState.categoryName),
+                        text = currentState.editSession.expenseDraft.toExpenseView(),
                         actions = emptyList(),
                     ),
                     outgoingMessage(

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDateEditSelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDateEditSelectionHandler.kt
@@ -39,7 +39,7 @@ class AwaitingExpenseDateEditSelectionHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
+                    expenseId = currentState.editSession.expenseId,
                 )
 
             UserCommand.FinishExpenseEdit ->
@@ -47,8 +47,7 @@ class AwaitingExpenseDateEditSelectionHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
-                    expenseDraft = currentState.expenseDraft,
+                    editSession = currentState.editSession,
                 )
 
             is UserCommand.SelectExpenseDate -> handleExpenseDateSelection(currentState, command.choice)
@@ -88,9 +87,10 @@ class AwaitingExpenseDateEditSelectionHandler(
         expenseDate: LocalDate,
     ): HandlerResponse =
         buildDraftExpenseEditFieldSelectionResult(
-            expenseId = currentState.expenseId,
-            expenseDraft = currentState.expenseDraft.copy(expenseDate = expenseDate),
-            categoryName = currentState.categoryName,
+            editSession =
+                currentState.editSession.withExpenseDraft(
+                    currentState.editSession.expenseDraft.copy(expenseDate = expenseDate),
+                ),
         )
 
     private fun requestManualDateInput(currentState: UserState.AwaitingExpenseDateEditSelection): HandlerResponse =
@@ -98,7 +98,7 @@ class AwaitingExpenseDateEditSelectionHandler(
             messages =
                 listOf(
                     outgoingMessage(
-                        text = currentState.expenseDraft.toExpenseView(categoryName = currentState.categoryName),
+                        text = currentState.editSession.expenseDraft.toExpenseView(),
                         actions = emptyList(),
                     ),
                     outgoingMessage(
@@ -108,9 +108,7 @@ class AwaitingExpenseDateEditSelectionHandler(
                 ),
             nextState =
                 UserState.AwaitingExpenseDateEditManualInput(
-                    expenseId = currentState.expenseId,
-                    expenseDraft = currentState.expenseDraft,
-                    categoryName = currentState.categoryName,
+                    editSession = currentState.editSession,
                 ),
         )
 
@@ -119,7 +117,7 @@ class AwaitingExpenseDateEditSelectionHandler(
             messages =
                 listOf(
                     outgoingMessage(
-                        text = currentState.expenseDraft.toExpenseView(categoryName = currentState.categoryName),
+                        text = currentState.editSession.expenseDraft.toExpenseView(),
                         actions = emptyList(),
                     ),
                     outgoingMessage(

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDateSelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDateSelectionHandler.kt
@@ -84,8 +84,6 @@ class AwaitingExpenseDateSelectionHandler(
         return expenseSavedResult(
             expenseDraft = expenseDraft,
             expenseId = expense.id,
-            categoryName = currentState.categoryName,
-            expenseDate = expense.expenseDate,
         )
     }
 
@@ -94,7 +92,7 @@ class AwaitingExpenseDateSelectionHandler(
             messages =
                 listOf(
                     outgoingMessage(
-                        text = currentState.expenseDraft.toExpenseView(categoryName = currentState.categoryName),
+                        text = currentState.expenseDraft.toExpenseView(),
                         actions = emptyList(),
                     ),
                     outgoingMessage(
@@ -105,7 +103,6 @@ class AwaitingExpenseDateSelectionHandler(
             nextState =
                 UserState.AwaitingExpenseManualDateInput(
                     expenseDraft = currentState.expenseDraft,
-                    categoryName = currentState.categoryName,
                 ),
         )
 
@@ -114,7 +111,7 @@ class AwaitingExpenseDateSelectionHandler(
             messages =
                 listOf(
                     outgoingMessage(
-                        text = currentState.expenseDraft.toExpenseView(categoryName = currentState.categoryName),
+                        text = currentState.expenseDraft.toExpenseView(),
                         actions = emptyList(),
                     ),
                     outgoingMessage(
@@ -151,8 +148,6 @@ class AwaitingExpenseDateSelectionHandler(
     private fun expenseSavedResult(
         expenseDraft: ExpenseDraft,
         expenseId: UUID,
-        categoryName: String,
-        expenseDate: LocalDate,
     ): HandlerResponse =
         handlerResponse(
             messages =
@@ -162,7 +157,7 @@ class AwaitingExpenseDateSelectionHandler(
                         actions = listOf(BotAction.RemoveReplyKeyboard),
                     ),
                     outgoingMessage(
-                        text = expenseDraft.toExpenseView(categoryName = categoryName, expenseDate = expenseDate),
+                        text = expenseDraft.toExpenseView(),
                         actions = listOf(BotAction.ShowExpenseCardActions(expenseId)),
                     ),
                 ),

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDescriptionEditHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseDescriptionEditHandler.kt
@@ -34,7 +34,7 @@ class AwaitingExpenseDescriptionEditHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
+                    expenseId = currentState.editSession.expenseId,
                 )
 
             UserCommand.FinishExpenseEdit ->
@@ -42,8 +42,7 @@ class AwaitingExpenseDescriptionEditHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
-                    expenseDraft = currentState.expenseDraft,
+                    editSession = currentState.editSession,
                 )
 
             is UserCommand.PlainText -> saveDescription(currentState, command.value)
@@ -61,9 +60,10 @@ class AwaitingExpenseDescriptionEditHandler(
         }
 
         return buildDraftExpenseEditFieldSelectionResult(
-            expenseId = currentState.expenseId,
-            expenseDraft = currentState.expenseDraft.copy(description = normalizedDescription),
-            categoryName = currentState.categoryName,
+            editSession =
+                currentState.editSession.withExpenseDraft(
+                    currentState.editSession.expenseDraft.copy(description = normalizedDescription),
+                ),
         )
     }
 

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseEditFieldSelectionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseEditFieldSelectionHandler.kt
@@ -35,7 +35,7 @@ class AwaitingExpenseEditFieldSelectionHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
+                    expenseId = currentState.editSession.expenseId,
                 )
 
             UserCommand.FinishExpenseEdit ->
@@ -43,8 +43,7 @@ class AwaitingExpenseEditFieldSelectionHandler(
                     expenseService = expenseService,
                     categoryService = categoryService,
                     userId = input.userId,
-                    expenseId = currentState.expenseId,
-                    expenseDraft = currentState.expenseDraft,
+                    editSession = currentState.editSession,
                 )
 
             is UserCommand.SelectExpenseEditField -> selectEditField(input, currentState, command.field)
@@ -67,9 +66,7 @@ class AwaitingExpenseEditFieldSelectionHandler(
                         ),
                     nextState =
                         UserState.AwaitingExpenseAmountEdit(
-                            expenseId = currentState.expenseId,
-                            expenseDraft = currentState.expenseDraft,
-                            categoryName = currentState.categoryName,
+                            editSession = currentState.editSession,
                         ),
                 )
 
@@ -86,9 +83,7 @@ class AwaitingExpenseEditFieldSelectionHandler(
                         ),
                     nextState =
                         UserState.AwaitingExpenseDescriptionEdit(
-                            expenseId = currentState.expenseId,
-                            expenseDraft = currentState.expenseDraft,
-                            categoryName = currentState.categoryName,
+                            editSession = currentState.editSession,
                         ),
                 )
         }
@@ -114,7 +109,7 @@ class AwaitingExpenseEditFieldSelectionHandler(
             messages =
                 listOf(
                     outgoingMessage(
-                        text = currentState.expenseDraft.toExpenseView(categoryName = currentState.categoryName),
+                        text = currentState.editSession.expenseDraft.toExpenseView(),
                         actions = emptyList(),
                     ),
                     outgoingMessage(
@@ -124,9 +119,7 @@ class AwaitingExpenseEditFieldSelectionHandler(
                 ),
             nextState =
                 UserState.AwaitingExpenseCategoryEdit(
-                    expenseId = currentState.expenseId,
-                    expenseDraft = currentState.expenseDraft,
-                    categoryName = currentState.categoryName,
+                    editSession = currentState.editSession,
                 ),
         )
     }
@@ -139,7 +132,7 @@ class AwaitingExpenseEditFieldSelectionHandler(
             messages =
                 listOf(
                     outgoingMessage(
-                        text = currentState.expenseDraft.toExpenseView(categoryName = currentState.categoryName),
+                        text = currentState.editSession.expenseDraft.toExpenseView(),
                         actions = emptyList(),
                     ),
                     outgoingMessage(
@@ -149,9 +142,7 @@ class AwaitingExpenseEditFieldSelectionHandler(
                 ),
             nextState =
                 UserState.AwaitingExpenseDateEditSelection(
-                    expenseId = currentState.expenseId,
-                    expenseDraft = currentState.expenseDraft,
-                    categoryName = currentState.categoryName,
+                    editSession = currentState.editSession,
                 ),
         )
 

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseManualDateInputHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/AwaitingExpenseManualDateInputHandler.kt
@@ -79,8 +79,6 @@ class AwaitingExpenseManualDateInputHandler(
         return expenseSavedResult(
             expenseDraft = expenseDraft,
             expenseId = expense.id,
-            categoryName = currentState.categoryName,
-            expenseDate = expense.expenseDate,
         )
     }
 
@@ -89,7 +87,7 @@ class AwaitingExpenseManualDateInputHandler(
             messages =
                 listOf(
                     outgoingMessage(
-                        text = currentState.expenseDraft.toExpenseView(categoryName = currentState.categoryName),
+                        text = currentState.expenseDraft.toExpenseView(),
                         actions = emptyList(),
                     ),
                     outgoingMessage(
@@ -126,8 +124,6 @@ class AwaitingExpenseManualDateInputHandler(
     private fun expenseSavedResult(
         expenseDraft: ExpenseDraft,
         expenseId: UUID,
-        categoryName: String,
-        expenseDate: LocalDate,
     ): HandlerResponse =
         handlerResponse(
             messages =
@@ -137,7 +133,7 @@ class AwaitingExpenseManualDateInputHandler(
                         actions = listOf(BotAction.RemoveReplyKeyboard),
                     ),
                     outgoingMessage(
-                        text = expenseDraft.toExpenseView(categoryName = categoryName, expenseDate = expenseDate),
+                        text = expenseDraft.toExpenseView(),
                         actions = listOf(BotAction.ShowExpenseCardActions(expenseId)),
                     ),
                 ),

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/ExpenseCardActionHandler.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/ExpenseCardActionHandler.kt
@@ -4,7 +4,7 @@ import me.kmozze.expensetracker.handler.handlerResponse
 import me.kmozze.expensetracker.handler.outgoingMessage
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
-import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.ResponseDelivery
 import me.kmozze.expensetracker.model.domain.UserInput
@@ -37,12 +37,11 @@ class ExpenseCardActionHandler(
                 userId = input.userId,
             ) ?: return expenseUnavailableResult(input)
 
-        val expenseDraft =
-            ExpenseDraft(
-                amount = expense.amount,
-                description = expense.description,
-                categoryId = expense.categoryId,
-                expenseDate = expense.expenseDate,
+        val expenseDraft = expense.toExpenseDraft(category.name)
+        val editSession =
+            ExpenseEditSession(
+                expenseId = expense.id,
+                expenseDraft = expenseDraft,
             )
 
         return handlerResponse(
@@ -50,7 +49,7 @@ class ExpenseCardActionHandler(
                 listOf(
                     outgoingMessage(
                         text =
-                            expense.toExpenseView(category),
+                            expenseDraft.toExpenseView(),
                         actions = listOf(BotAction.ClearInlineKeyboard),
                         delivery = input.callbackMessageDelivery(),
                     ),
@@ -61,9 +60,7 @@ class ExpenseCardActionHandler(
                 ),
             nextState =
                 UserState.AwaitingExpenseEditFieldSelection(
-                    expenseId = expense.id,
-                    expenseDraft = expenseDraft,
-                    categoryName = category.name,
+                    editSession = editSession,
                 ),
         )
     }
@@ -76,7 +73,7 @@ class ExpenseCardActionHandler(
             input = input,
             expenseId = expenseId,
             textFactory = { expense, category ->
-                expense.toExpenseView(category)
+                expense.toExpenseView(category.name)
             },
             actionsFactory = { listOf(BotAction.ShowExpenseDeletionConfirmation(expenseId)) },
         )
@@ -89,7 +86,7 @@ class ExpenseCardActionHandler(
             input = input,
             expenseId = expenseId,
             textFactory = { expense, category ->
-                expense.toExpenseView(category)
+                expense.toExpenseView(category.name)
             },
             actionsFactory = { listOf(BotAction.ShowExpenseCardActions(expenseId)) },
         )

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/ExpenseEditStateHelpers.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/ExpenseEditStateHelpers.kt
@@ -5,14 +5,12 @@ import me.kmozze.expensetracker.handler.outgoingMessage
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.OutgoingMessage
 import me.kmozze.expensetracker.model.domain.UserState
-import me.kmozze.expensetracker.model.entity.Category
-import me.kmozze.expensetracker.model.entity.Expense
 import me.kmozze.expensetracker.service.CategoryService
 import me.kmozze.expensetracker.service.ExpenseService
-import java.time.LocalDate
 import java.util.UUID
 
 internal fun buildUpdatedExpenseResult(
@@ -39,7 +37,7 @@ internal fun buildUpdatedExpenseResult(
 
             add(
                 outgoingMessage(
-                    text = expense.toExpenseView(category),
+                    text = expense.toExpenseView(category.name),
                     actions = listOf(BotAction.ShowExpenseCardActions(expense.id)),
                 ),
             )
@@ -66,16 +64,12 @@ internal fun cancelExpenseEdit(
         prefixText = BotText.Done,
     )
 
-internal fun buildDraftExpenseEditFieldSelectionResult(
-    expenseId: UUID,
-    expenseDraft: ExpenseDraft,
-    categoryName: String,
-): HandlerResponse =
+internal fun buildDraftExpenseEditFieldSelectionResult(editSession: ExpenseEditSession): HandlerResponse =
     handlerResponse(
         messages =
             listOf(
                 outgoingMessage(
-                    text = expenseDraft.toExpenseView(categoryName = categoryName),
+                    text = editSession.expenseDraft.toExpenseView(),
                     actions = emptyList(),
                 ),
                 outgoingMessage(
@@ -85,24 +79,23 @@ internal fun buildDraftExpenseEditFieldSelectionResult(
             ),
         nextState =
             UserState.AwaitingExpenseEditFieldSelection(
-                expenseId = expenseId,
-                expenseDraft = expenseDraft,
-                categoryName = categoryName,
+                editSession = editSession,
             ),
     )
+
+internal fun ExpenseEditSession.withExpenseDraft(expenseDraft: ExpenseDraft): ExpenseEditSession = copy(expenseDraft = expenseDraft)
 
 internal fun finishExpenseEdit(
     expenseService: ExpenseService,
     categoryService: CategoryService,
     userId: Long,
-    expenseId: UUID,
-    expenseDraft: ExpenseDraft,
+    editSession: ExpenseEditSession,
 ): HandlerResponse {
     val updatedExpense =
         expenseService.updateExpenseFromDraftForUser(
             userId = userId,
-            expenseId = expenseId,
-            expenseDraft = expenseDraft,
+            expenseId = editSession.expenseId,
+            expenseDraft = editSession.expenseDraft,
         ) ?: return expenseEditUnavailableResult()
 
     val category =
@@ -119,32 +112,13 @@ internal fun finishExpenseEdit(
                     actions = listOf(BotAction.RemoveReplyKeyboard),
                 ),
                 outgoingMessage(
-                    text = updatedExpense.toExpenseView(category),
+                    text = updatedExpense.toExpenseView(category.name),
                     actions = listOf(BotAction.ShowExpenseCardActions(updatedExpense.id)),
                 ),
             ),
         nextState = UserState.Idle,
     )
 }
-
-internal fun Expense.toExpenseView(category: Category): BotText.ExpenseView =
-    BotText.ExpenseView(
-        amount = amount,
-        categoryName = category.name,
-        expenseDate = expenseDate,
-        description = description,
-    )
-
-internal fun ExpenseDraft.toExpenseView(
-    categoryName: String? = null,
-    expenseDate: LocalDate? = this.expenseDate,
-): BotText.ExpenseView =
-    BotText.ExpenseView(
-        amount = amount,
-        categoryName = categoryName,
-        expenseDate = expenseDate,
-        description = description,
-    )
 
 internal fun expenseEditUnavailableResult(): HandlerResponse =
     handlerResponse(

--- a/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/ExpenseMappers.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/handler/statehandler/ExpenseMappers.kt
@@ -1,0 +1,30 @@
+package me.kmozze.expensetracker.handler.statehandler
+
+import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
+import me.kmozze.expensetracker.model.entity.Expense
+
+internal fun Expense.toExpenseDraft(categoryName: String): ExpenseDraft =
+    ExpenseDraft(
+        amount = amount,
+        description = description,
+        category = ExpenseDraftCategory(categoryId = categoryId, name = categoryName),
+        expenseDate = expenseDate,
+    )
+
+internal fun Expense.toExpenseView(categoryName: String): BotText.ExpenseView =
+    BotText.ExpenseView(
+        amount = amount,
+        categoryName = categoryName,
+        expenseDate = expenseDate,
+        description = description,
+    )
+
+internal fun ExpenseDraft.toExpenseView(): BotText.ExpenseView =
+    BotText.ExpenseView(
+        amount = amount,
+        categoryName = category?.name,
+        expenseDate = expenseDate,
+        description = description,
+    )

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/ExpenseDraft.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/ExpenseDraft.kt
@@ -3,15 +3,20 @@ package me.kmozze.expensetracker.model.domain
 import java.time.LocalDate
 import java.util.UUID
 
+data class ExpenseDraftCategory(
+    val categoryId: UUID,
+    val name: String,
+)
+
 data class ExpenseDraft(
     val amount: Money,
     val description: String?,
-    val categoryId: UUID? = null,
+    val category: ExpenseDraftCategory? = null,
     val expenseDate: LocalDate? = null,
 ) {
     fun requireCategoryId(): UUID =
-        requireNotNull(categoryId) {
-            "ExpenseDraft.categoryId must be set before saving"
+        requireNotNull(category?.categoryId) {
+            "ExpenseDraft.category must be set before saving"
         }
 
     fun requireExpenseDate(): LocalDate =
@@ -19,3 +24,8 @@ data class ExpenseDraft(
             "ExpenseDraft.expenseDate must be set before saving"
         }
 }
+
+data class ExpenseEditSession(
+    val expenseId: UUID,
+    val expenseDraft: ExpenseDraft,
+)

--- a/src/main/kotlin/me/kmozze/expensetracker/model/domain/UserState.kt
+++ b/src/main/kotlin/me/kmozze/expensetracker/model/domain/UserState.kt
@@ -1,7 +1,5 @@
 package me.kmozze.expensetracker.model.domain
 
-import java.util.UUID
-
 sealed class UserState {
     data object Idle : UserState()
 
@@ -13,47 +11,33 @@ sealed class UserState {
 
     data class AwaitingExpenseDateSelection(
         val expenseDraft: ExpenseDraft,
-        val categoryName: String,
     ) : UserState()
 
     data class AwaitingExpenseManualDateInput(
         val expenseDraft: ExpenseDraft,
-        val categoryName: String,
     ) : UserState()
 
     data class AwaitingExpenseEditFieldSelection(
-        val expenseId: UUID,
-        val expenseDraft: ExpenseDraft,
-        val categoryName: String,
+        val editSession: ExpenseEditSession,
     ) : UserState()
 
     data class AwaitingExpenseAmountEdit(
-        val expenseId: UUID,
-        val expenseDraft: ExpenseDraft,
-        val categoryName: String,
+        val editSession: ExpenseEditSession,
     ) : UserState()
 
     data class AwaitingExpenseCategoryEdit(
-        val expenseId: UUID,
-        val expenseDraft: ExpenseDraft,
-        val categoryName: String,
+        val editSession: ExpenseEditSession,
     ) : UserState()
 
     data class AwaitingExpenseDateEditSelection(
-        val expenseId: UUID,
-        val expenseDraft: ExpenseDraft,
-        val categoryName: String,
+        val editSession: ExpenseEditSession,
     ) : UserState()
 
     data class AwaitingExpenseDateEditManualInput(
-        val expenseId: UUID,
-        val expenseDraft: ExpenseDraft,
-        val categoryName: String,
+        val editSession: ExpenseEditSession,
     ) : UserState()
 
     data class AwaitingExpenseDescriptionEdit(
-        val expenseId: UUID,
-        val expenseDraft: ExpenseDraft,
-        val categoryName: String,
+        val editSession: ExpenseEditSession,
     ) : UserState()
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/AddExpenseFlowTest.kt
@@ -7,6 +7,7 @@ import me.kmozze.expensetracker.handler.DialogueRouter
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.OutgoingMessage
@@ -87,8 +88,7 @@ class AddExpenseFlowTest : AbstractFlowIntegrationTest() {
         assertThat(dateSelectionResult.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseDateSelection(
-                    expenseDraft = EXPENSE_WITH_DESCRIPTION.copy(categoryId = category.id),
-                    categoryName = category.name,
+                    expenseDraft = EXPENSE_WITH_DESCRIPTION.withCategory(category),
                 ),
             )
         assertThat(findExpenses(userId)).isEmpty()
@@ -171,8 +171,7 @@ class AddExpenseFlowTest : AbstractFlowIntegrationTest() {
         assertThat(manualDateInputResult.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseManualDateInput(
-                    expenseDraft = EXPENSE_WITHOUT_DESCRIPTION.copy(categoryId = category.id),
-                    categoryName = category.name,
+                    expenseDraft = EXPENSE_WITHOUT_DESCRIPTION.withCategory(category),
                 ),
             )
 
@@ -241,8 +240,7 @@ class AddExpenseFlowTest : AbstractFlowIntegrationTest() {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseManualDateInput(
-                    expenseDraft = EXPENSE_WITH_DESCRIPTION.copy(categoryId = category.id),
-                    categoryName = category.name,
+                    expenseDraft = EXPENSE_WITH_DESCRIPTION.withCategory(category),
                 ),
             )
         assertThat(findExpenses(userId)).isEmpty()
@@ -508,8 +506,7 @@ class AddExpenseFlowTest : AbstractFlowIntegrationTest() {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseDateSelection(
-                    expenseDraft = expenseDraft.copy(categoryId = category.id),
-                    categoryName = category.name,
+                    expenseDraft = expenseDraft.withCategory(category),
                 ),
             )
 
@@ -531,6 +528,15 @@ class AddExpenseFlowTest : AbstractFlowIntegrationTest() {
             userId = userId,
             from = TEST_PERIOD_FROM,
             to = TEST_PERIOD_TO,
+        )
+
+    private fun ExpenseDraft.withCategory(category: Category): ExpenseDraft =
+        copy(
+            category =
+                ExpenseDraftCategory(
+                    categoryId = category.id,
+                    name = category.name,
+                ),
         )
 
     private fun HandlerResponse.categorySelectionAction(): BotAction.ShowCategorySelection =

--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/EditExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/EditExpenseFlowTest.kt
@@ -6,6 +6,8 @@ import me.kmozze.expensetracker.handler.DialogueRouter
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.ResponseDelivery
@@ -56,7 +58,7 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         assertThat(editStart.outgoingMessages[0].delivery).isEqualTo(ResponseDelivery.EditMessage(CARD_MESSAGE_ID))
         assertThat(editStart.outgoingMessages[1].text).isEqualTo(BotText.EditExpenseFieldSelection)
         assertThat(editStart.outgoingMessages[1].actions).containsExactly(BotAction.ShowExpenseEditFieldSelection)
-        val initialDraft = createdExpense.first.toDraft()
+        val initialDraft = createdExpense.first.toDraft(initialCategory)
         assertThat(editStart.nextState).isEqualTo(editFieldSelectionState(createdExpense.first, initialCategory))
 
         val amountPrompt =
@@ -77,9 +79,7 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         ).containsExactly(BotAction.ShowCancel)
         assertThat(amountPrompt.nextState).isEqualTo(
             UserState.AwaitingExpenseAmountEdit(
-                expenseId = createdExpense.first.id,
-                expenseDraft = initialDraft,
-                categoryName = initialCategory.name,
+                editSession = editSession(createdExpense.first.id, initialDraft),
             ),
         )
 
@@ -109,9 +109,7 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         val amountDraft = initialDraft.copy(amount = EXPENSE_AMOUNT_UPDATED)
         assertThat(amountUpdated.nextState).isEqualTo(
             UserState.AwaitingExpenseEditFieldSelection(
-                expenseId = createdExpense.first.id,
-                expenseDraft = amountDraft,
-                categoryName = initialCategory.name,
+                editSession = editSession(createdExpense.first.id, amountDraft),
             ),
         )
         assertThat(expenseById(userId, createdExpense.first.id).amount).isEqualTo(EXPENSE_AMOUNT)
@@ -125,9 +123,7 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         val categorySelection = categorySelectionPrompt.categorySelectionAction()
         assertThat(categorySelectionPrompt.nextState).isEqualTo(
             UserState.AwaitingExpenseCategoryEdit(
-                expenseId = createdExpense.first.id,
-                expenseDraft = amountDraft,
-                categoryName = initialCategory.name,
+                editSession = editSession(createdExpense.first.id, amountDraft),
             ),
         )
         val newCategory =
@@ -152,12 +148,17 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
             ),
             BotText.EditExpenseFieldSelection,
         )
-        val categoryDraft = amountDraft.copy(categoryId = newCategory.id)
+        val categoryDraft =
+            amountDraft.copy(
+                category =
+                    ExpenseDraftCategory(
+                        categoryId = newCategory.id,
+                        name = newCategory.name,
+                    ),
+            )
         assertThat(categoryUpdated.nextState).isEqualTo(
             UserState.AwaitingExpenseEditFieldSelection(
-                expenseId = createdExpense.first.id,
-                expenseDraft = categoryDraft,
-                categoryName = newCategory.name,
+                editSession = editSession(createdExpense.first.id, categoryDraft),
             ),
         )
 
@@ -186,9 +187,7 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         ).containsExactly(BotAction.ShowExpenseDateSelection)
         assertThat(dateSelectionPrompt.nextState).isEqualTo(
             UserState.AwaitingExpenseDateEditSelection(
-                expenseId = createdExpense.first.id,
-                expenseDraft = categoryDraft,
-                categoryName = newCategory.name,
+                editSession = editSession(createdExpense.first.id, categoryDraft),
             ),
         )
         val manualDatePrompt =
@@ -211,9 +210,7 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         )
         assertThat(manualDatePrompt.nextState).isEqualTo(
             UserState.AwaitingExpenseDateEditManualInput(
-                expenseId = createdExpense.first.id,
-                expenseDraft = categoryDraft,
-                categoryName = newCategory.name,
+                editSession = editSession(createdExpense.first.id, categoryDraft),
             ),
         )
 
@@ -238,9 +235,7 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         )
         assertThat(dateUpdated.nextState).isEqualTo(
             UserState.AwaitingExpenseEditFieldSelection(
-                expenseId = createdExpense.first.id,
-                expenseDraft = dateDraft,
-                categoryName = newCategory.name,
+                editSession = editSession(createdExpense.first.id, dateDraft),
             ),
         )
 
@@ -262,9 +257,7 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         ).containsExactly(BotAction.ShowCancel)
         assertThat(descriptionPrompt.nextState).isEqualTo(
             UserState.AwaitingExpenseDescriptionEdit(
-                expenseId = createdExpense.first.id,
-                expenseDraft = dateDraft,
-                categoryName = newCategory.name,
+                editSession = editSession(createdExpense.first.id, dateDraft),
             ),
         )
 
@@ -289,9 +282,7 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         )
         assertThat(descriptionUpdated.nextState).isEqualTo(
             UserState.AwaitingExpenseEditFieldSelection(
-                expenseId = createdExpense.first.id,
-                expenseDraft = finalDraft,
-                categoryName = newCategory.name,
+                editSession = editSession(createdExpense.first.id, finalDraft),
             ),
         )
         val unchangedBeforeFinish = expenseById(userId, createdExpense.first.id)
@@ -465,8 +456,14 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseDateSelection(
-                    expenseDraft = expenseDraft.copy(categoryId = category.id),
-                    categoryName = category.name,
+                    expenseDraft =
+                        expenseDraft.copy(
+                            category =
+                                ExpenseDraftCategory(
+                                    categoryId = category.id,
+                                    name = category.name,
+                                ),
+                        ),
                 ),
             )
 
@@ -508,16 +505,23 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
         category: Category,
     ): UserState.AwaitingExpenseEditFieldSelection =
         UserState.AwaitingExpenseEditFieldSelection(
-            expenseId = expense.id,
-            expenseDraft = expense.toDraft(),
-            categoryName = category.name,
+            editSession = editSession(expense.id, expense.toDraft(category)),
         )
 
-    private fun Expense.toDraft(): ExpenseDraft =
+    private fun editSession(
+        expenseId: UUID,
+        expenseDraft: ExpenseDraft,
+    ): ExpenseEditSession =
+        ExpenseEditSession(
+            expenseId = expenseId,
+            expenseDraft = expenseDraft,
+        )
+
+    private fun Expense.toDraft(category: Category): ExpenseDraft =
         ExpenseDraft(
             amount = amount,
             description = description,
-            categoryId = categoryId,
+            category = ExpenseDraftCategory(categoryId = categoryId, name = category.name),
             expenseDate = expenseDate,
         )
 

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/RoutingHandlerTest.kt
@@ -11,6 +11,7 @@ import me.kmozze.expensetracker.handler.statehandler.StateHandler
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.OutgoingMessage
@@ -198,7 +199,6 @@ class RoutingHandlerTest {
         val currentState =
             UserState.AwaitingExpenseManualDateInput(
                 expenseDraft = ExpenseDraft(Money.of(BigDecimal("500")), "такси"),
-                categoryName = "Транспорт",
             )
         val router = routerWith(awaitingManualDateHandler)
 
@@ -226,9 +226,11 @@ class RoutingHandlerTest {
         val expenseId = UUID.fromString("c3a0e10f-cf0d-4f95-8a12-123456789abc")
         val currentState =
             UserState.AwaitingExpenseAmountEdit(
-                expenseId = expenseId,
-                expenseDraft = ExpenseDraft(Money.of(BigDecimal("100.00")), "такси"),
-                categoryName = "Транспорт",
+                editSession =
+                    ExpenseEditSession(
+                        expenseId = expenseId,
+                        expenseDraft = ExpenseDraft(Money.of(BigDecimal("100.00")), "такси"),
+                    ),
             )
         val router = routerWith(awaitingAmountEditHandler)
 

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingCategorySelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingCategorySelectionHandlerTest.kt
@@ -10,6 +10,7 @@ import me.kmozze.expensetracker.handler.statehandler.AwaitingCategorySelectionHa
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
@@ -59,8 +60,10 @@ class AwaitingCategorySelectionHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseDateSelection(
-                    expenseDraft = EXPENSE_DRAFT.copy(categoryId = CATEGORY_ID),
-                    categoryName = category.name,
+                    expenseDraft =
+                        EXPENSE_DRAFT.copy(
+                            category = ExpenseDraftCategory(categoryId = CATEGORY_ID, name = category.name),
+                        ),
                 ),
             )
         verify(exactly = 1) { categoryService.getCategories(USER_ID) }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseAmountEditHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseAmountEditHandlerTest.kt
@@ -11,6 +11,8 @@ import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseAmountEditHa
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
@@ -66,9 +68,7 @@ class AwaitingExpenseAmountEditHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseEditFieldSelection(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = updatedDraft,
-                    categoryName = CATEGORY.name,
+                    editSession = ExpenseEditSession(expenseId = EXPENSE_ID, expenseDraft = updatedDraft),
                 ),
             )
         verify(exactly = 1) { expenseService.parseExpenseAmount("650") }
@@ -162,8 +162,13 @@ class AwaitingExpenseAmountEditHandlerTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = EXPENSE_DESCRIPTION,
-                categoryId = CATEGORY_ID,
+                category = ExpenseDraftCategory(categoryId = CATEGORY_ID, name = CATEGORY.name),
                 expenseDate = EXPENSE_DATE,
+            )
+        val EDIT_SESSION: ExpenseEditSession =
+            ExpenseEditSession(
+                expenseId = EXPENSE_ID,
+                expenseDraft = EXPENSE_DRAFT,
             )
         val EXPENSE: Expense =
             Expense(
@@ -183,9 +188,7 @@ class AwaitingExpenseAmountEditHandlerTest {
             )
         val AWAITING_EXPENSE_AMOUNT_EDIT: UserState.AwaitingExpenseAmountEdit =
             UserState.AwaitingExpenseAmountEdit(
-                expenseId = EXPENSE_ID,
-                expenseDraft = EXPENSE_DRAFT,
-                categoryName = CATEGORY.name,
+                editSession = EDIT_SESSION,
             )
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseCategoryEditHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseCategoryEditHandlerTest.kt
@@ -10,6 +10,8 @@ import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseCategoryEdit
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
@@ -48,7 +50,10 @@ class AwaitingExpenseCategoryEditHandlerTest {
 
         val result = handle(UserCommand.PlainText(UPDATED_CATEGORY.name))
 
-        val updatedDraft = EXPENSE_DRAFT.copy(categoryId = UPDATED_CATEGORY_ID)
+        val updatedDraft =
+            EXPENSE_DRAFT.copy(
+                category = ExpenseDraftCategory(categoryId = UPDATED_CATEGORY_ID, name = UPDATED_CATEGORY.name),
+            )
         assertThat(result.outgoingMessages).hasSize(2)
         assertThat(result.outgoingMessages[0].text)
             .isEqualTo(
@@ -65,9 +70,7 @@ class AwaitingExpenseCategoryEditHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseEditFieldSelection(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = updatedDraft,
-                    categoryName = UPDATED_CATEGORY.name,
+                    editSession = ExpenseEditSession(expenseId = EXPENSE_ID, expenseDraft = updatedDraft),
                 ),
             )
         verify(exactly = 1) { categoryService.getCategories(USER_ID) }
@@ -181,8 +184,13 @@ class AwaitingExpenseCategoryEditHandlerTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = EXPENSE_DESCRIPTION,
-                categoryId = EXISTING_CATEGORY_ID,
+                category = ExpenseDraftCategory(categoryId = EXISTING_CATEGORY_ID, name = EXISTING_CATEGORY.name),
                 expenseDate = EXPENSE_DATE,
+            )
+        val EDIT_SESSION =
+            ExpenseEditSession(
+                expenseId = EXPENSE_ID,
+                expenseDraft = EXPENSE_DRAFT,
             )
         val EXPENSE =
             Expense(
@@ -202,9 +210,7 @@ class AwaitingExpenseCategoryEditHandlerTest {
             )
         val AWAITING_EXPENSE_CATEGORY_EDIT =
             UserState.AwaitingExpenseCategoryEdit(
-                expenseId = EXPENSE_ID,
-                expenseDraft = EXPENSE_DRAFT,
-                categoryName = EXISTING_CATEGORY.name,
+                editSession = EDIT_SESSION,
             )
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateEditManualInputHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateEditManualInputHandlerTest.kt
@@ -11,6 +11,8 @@ import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseDateEditManu
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
@@ -66,9 +68,7 @@ class AwaitingExpenseDateEditManualInputHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseEditFieldSelection(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = updatedDraft,
-                    categoryName = CATEGORY.name,
+                    editSession = ExpenseEditSession(expenseId = EXPENSE_ID, expenseDraft = updatedDraft),
                 ),
             )
         verify(exactly = 1) { expenseService.parseExpenseDate(MANUAL_DATE_TEXT) }
@@ -158,8 +158,13 @@ class AwaitingExpenseDateEditManualInputHandlerTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = EXPENSE_DESCRIPTION,
-                categoryId = CATEGORY_ID,
+                category = ExpenseDraftCategory(categoryId = CATEGORY_ID, name = CATEGORY.name),
                 expenseDate = EXPENSE_DATE,
+            )
+        val EDIT_SESSION =
+            ExpenseEditSession(
+                expenseId = EXPENSE_ID,
+                expenseDraft = EXPENSE_DRAFT,
             )
         val EXPENSE =
             Expense(
@@ -179,9 +184,7 @@ class AwaitingExpenseDateEditManualInputHandlerTest {
             )
         val AWAITING_EXPENSE_DATE_EDIT_MANUAL_INPUT =
             UserState.AwaitingExpenseDateEditManualInput(
-                expenseId = EXPENSE_ID,
-                expenseDraft = EXPENSE_DRAFT,
-                categoryName = CATEGORY.name,
+                editSession = EDIT_SESSION,
             )
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateEditSelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateEditSelectionHandlerTest.kt
@@ -11,6 +11,8 @@ import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDateChoice
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
@@ -75,9 +77,7 @@ class AwaitingExpenseDateEditSelectionHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseDateEditManualInput(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = EXPENSE_DRAFT,
-                    categoryName = CATEGORY.name,
+                    editSession = EDIT_SESSION,
                 ),
             )
         confirmVerified(expenseService, categoryService)
@@ -130,9 +130,7 @@ class AwaitingExpenseDateEditSelectionHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseEditFieldSelection(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = updatedDraft,
-                    categoryName = CATEGORY.name,
+                    editSession = ExpenseEditSession(expenseId = EXPENSE_ID, expenseDraft = updatedDraft),
                 ),
             )
     }
@@ -183,8 +181,13 @@ class AwaitingExpenseDateEditSelectionHandlerTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = EXPENSE.description,
-                categoryId = CATEGORY_ID,
+                category = ExpenseDraftCategory(categoryId = CATEGORY_ID, name = CATEGORY.name),
                 expenseDate = TODAY,
+            )
+        val EDIT_SESSION: ExpenseEditSession =
+            ExpenseEditSession(
+                expenseId = EXPENSE_ID,
+                expenseDraft = EXPENSE_DRAFT,
             )
         val EXPENSE_VIEW: BotText.ExpenseView =
             BotText.ExpenseView(
@@ -195,9 +198,7 @@ class AwaitingExpenseDateEditSelectionHandlerTest {
             )
         val AWAITING_EXPENSE_DATE_EDIT_SELECTION: UserState.AwaitingExpenseDateEditSelection =
             UserState.AwaitingExpenseDateEditSelection(
-                expenseId = EXPENSE_ID,
-                expenseDraft = EXPENSE_DRAFT,
-                categoryName = CATEGORY.name,
+                editSession = EDIT_SESSION,
             )
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateSelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDateSelectionHandlerTest.kt
@@ -11,6 +11,7 @@ import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDateChoice
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
@@ -109,7 +110,6 @@ class AwaitingExpenseDateSelectionHandlerTest {
             .isEqualTo(
                 UserState.AwaitingExpenseManualDateInput(
                     expenseDraft = EXPENSE_DRAFT_WITH_CATEGORY,
-                    categoryName = CATEGORY_NAME,
                 ),
             )
         confirmVerified(expenseService)
@@ -191,12 +191,11 @@ class AwaitingExpenseDateSelectionHandlerTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = EXPENSE_DESCRIPTION,
-                categoryId = CATEGORY_ID,
+                category = ExpenseDraftCategory(categoryId = CATEGORY_ID, name = CATEGORY_NAME),
             )
         val AWAITING_EXPENSE_DATE_SELECTION: UserState.AwaitingExpenseDateSelection =
             UserState.AwaitingExpenseDateSelection(
                 expenseDraft = EXPENSE_DRAFT_WITH_CATEGORY,
-                categoryName = CATEGORY_NAME,
             )
         val CLOCK: Clock = Clock.fixed(Instant.parse("2026-05-24T12:00:00Z"), ZoneOffset.UTC)
         val TODAY: LocalDate = LocalDate.parse("2026-05-24")

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDescriptionEditHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseDescriptionEditHandlerTest.kt
@@ -9,6 +9,8 @@ import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseDescriptionE
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
@@ -63,9 +65,7 @@ class AwaitingExpenseDescriptionEditHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseEditFieldSelection(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = updatedDraft,
-                    categoryName = CATEGORY.name,
+                    editSession = ExpenseEditSession(expenseId = EXPENSE_ID, expenseDraft = updatedDraft),
                 ),
             )
         confirmVerified(expenseService, categoryService)
@@ -146,8 +146,13 @@ class AwaitingExpenseDescriptionEditHandlerTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = EXPENSE_DESCRIPTION,
-                categoryId = CATEGORY_ID,
+                category = ExpenseDraftCategory(categoryId = CATEGORY_ID, name = CATEGORY.name),
                 expenseDate = EXPENSE_DATE,
+            )
+        val EDIT_SESSION =
+            ExpenseEditSession(
+                expenseId = EXPENSE_ID,
+                expenseDraft = EXPENSE_DRAFT,
             )
         val EXPENSE =
             Expense(
@@ -167,9 +172,7 @@ class AwaitingExpenseDescriptionEditHandlerTest {
             )
         val AWAITING_EXPENSE_DESCRIPTION_EDIT =
             UserState.AwaitingExpenseDescriptionEdit(
-                expenseId = EXPENSE_ID,
-                expenseDraft = EXPENSE_DRAFT,
-                categoryName = CATEGORY.name,
+                editSession = EDIT_SESSION,
             )
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseEditFieldSelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseEditFieldSelectionHandlerTest.kt
@@ -9,7 +9,9 @@ import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseEditFieldSel
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
 import me.kmozze.expensetracker.model.domain.ExpenseEditField
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
@@ -50,9 +52,7 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseAmountEdit(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = EXPENSE_DRAFT,
-                    categoryName = CATEGORY.name,
+                    editSession = EDIT_SESSION,
                 ),
             )
         confirmVerified(expenseService, categoryService)
@@ -67,9 +67,7 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseDescriptionEdit(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = EXPENSE_DRAFT,
-                    categoryName = CATEGORY.name,
+                    editSession = EDIT_SESSION,
                 ),
             )
         confirmVerified(expenseService, categoryService)
@@ -89,9 +87,7 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseCategoryEdit(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = EXPENSE_DRAFT,
-                    categoryName = CATEGORY.name,
+                    editSession = EDIT_SESSION,
                 ),
             )
         verify(exactly = 1) { categoryService.getCategories(USER_ID) }
@@ -110,9 +106,7 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseDateEditSelection(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = EXPENSE_DRAFT,
-                    categoryName = CATEGORY.name,
+                    editSession = EDIT_SESSION,
                 ),
             )
         confirmVerified(expenseService, categoryService)
@@ -201,8 +195,13 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = "такси",
-                categoryId = CATEGORY_ID,
+                category = ExpenseDraftCategory(categoryId = CATEGORY_ID, name = CATEGORY.name),
                 expenseDate = EXPENSE_DATE,
+            )
+        val EDIT_SESSION: ExpenseEditSession =
+            ExpenseEditSession(
+                expenseId = EXPENSE_ID,
+                expenseDraft = EXPENSE_DRAFT,
             )
         val EXPENSE: Expense =
             Expense(
@@ -222,9 +221,7 @@ class AwaitingExpenseEditFieldSelectionHandlerTest {
             )
         val AWAITING_EXPENSE_EDIT_FIELD_SELECTION: UserState.AwaitingExpenseEditFieldSelection =
             UserState.AwaitingExpenseEditFieldSelection(
-                expenseId = EXPENSE_ID,
-                expenseDraft = EXPENSE_DRAFT,
-                categoryName = CATEGORY.name,
+                editSession = EDIT_SESSION,
             )
     }
 }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseManualDateInputHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/AwaitingExpenseManualDateInputHandlerTest.kt
@@ -11,6 +11,7 @@ import me.kmozze.expensetracker.handler.statehandler.AwaitingExpenseManualDateIn
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserCommand
 import me.kmozze.expensetracker.model.domain.UserState
@@ -166,12 +167,11 @@ class AwaitingExpenseManualDateInputHandlerTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = EXPENSE_DESCRIPTION,
-                categoryId = CATEGORY_ID,
+                category = ExpenseDraftCategory(categoryId = CATEGORY_ID, name = CATEGORY_NAME),
             )
         val AWAITING_EXPENSE_MANUAL_DATE_INPUT: UserState.AwaitingExpenseManualDateInput =
             UserState.AwaitingExpenseManualDateInput(
                 expenseDraft = EXPENSE_DRAFT_WITH_CATEGORY,
-                categoryName = CATEGORY_NAME,
             )
         val MANUAL_DATE: LocalDate = LocalDate.parse("2026-05-20")
     }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/ExpenseCardActionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/ExpenseCardActionHandlerTest.kt
@@ -8,6 +8,8 @@ import me.kmozze.expensetracker.handler.statehandler.ExpenseCardActionHandler
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.HandlerResponse
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.ResponseDelivery
@@ -147,9 +149,7 @@ class ExpenseCardActionHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseEditFieldSelection(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = EXPENSE_DRAFT,
-                    categoryName = CATEGORY.name,
+                    editSession = EDIT_SESSION,
                 ),
             )
         verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
@@ -171,9 +171,7 @@ class ExpenseCardActionHandlerTest {
         assertThat(result.nextState)
             .isEqualTo(
                 UserState.AwaitingExpenseEditFieldSelection(
-                    expenseId = EXPENSE_ID,
-                    expenseDraft = EXPENSE_DRAFT,
-                    categoryName = CATEGORY.name,
+                    editSession = EDIT_SESSION,
                 ),
             )
     }
@@ -407,8 +405,13 @@ class ExpenseCardActionHandlerTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = EXPENSE_DESCRIPTION,
-                categoryId = CATEGORY_ID,
+                category = ExpenseDraftCategory(categoryId = CATEGORY_ID, name = CATEGORY.name),
                 expenseDate = EXPENSE_DATE,
+            )
+        val EDIT_SESSION: ExpenseEditSession =
+            ExpenseEditSession(
+                expenseId = EXPENSE_ID,
+                expenseDraft = EXPENSE_DRAFT,
             )
         val EXPENSE_VIEW: BotText.ExpenseView =
             BotText.ExpenseView(

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/ExpenseEditStateHelpersTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/ExpenseEditStateHelpersTest.kt
@@ -7,8 +7,12 @@ import io.mockk.mockk
 import io.mockk.verify
 import me.kmozze.expensetracker.handler.statehandler.buildUpdatedExpenseResult
 import me.kmozze.expensetracker.handler.statehandler.expenseEditUnavailableResult
+import me.kmozze.expensetracker.handler.statehandler.finishExpenseEdit
 import me.kmozze.expensetracker.model.domain.BotAction
 import me.kmozze.expensetracker.model.domain.BotText
+import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
+import me.kmozze.expensetracker.model.domain.ExpenseEditSession
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.domain.UserState
 import me.kmozze.expensetracker.model.entity.Category
@@ -59,6 +63,57 @@ class ExpenseEditStateHelpersTest {
         assertThat(result.nextState).isEqualTo(UserState.Idle)
 
         verify(exactly = 1) { expenseService.findExpenseForUser(USER_ID, EXPENSE_ID) }
+        verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `finish expense edit uses fresh category name from saved expense card`() {
+        val draftCategoryName = "Старое имя в черновике"
+        val expenseDraft =
+            ExpenseDraft(
+                amount = EXPENSE.amount,
+                description = EXPENSE.description,
+                category = ExpenseDraftCategory(categoryId = CATEGORY_ID, name = draftCategoryName),
+                expenseDate = EXPENSE.expenseDate,
+            )
+        val editSession =
+            ExpenseEditSession(
+                expenseId = EXPENSE_ID,
+                expenseDraft = expenseDraft,
+            )
+        every { expenseService.updateExpenseFromDraftForUser(USER_ID, EXPENSE_ID, expenseDraft) } returns EXPENSE
+        every { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) } returns CATEGORY
+
+        val result =
+            finishExpenseEdit(
+                expenseService = expenseService,
+                categoryService = categoryService,
+                userId = USER_ID,
+                editSession = editSession,
+            )
+
+        assertThat(result.outgoingMessages).hasSize(2)
+        assertThat(result.outgoingMessages[1].text)
+            .isEqualTo(
+                BotText.ExpenseView(
+                    amount = EXPENSE.amount,
+                    categoryName = CATEGORY.name,
+                    expenseDate = EXPENSE.expenseDate,
+                    description = EXPENSE.description,
+                ),
+            )
+        assertThat(result.outgoingMessages[1].text)
+            .isNotEqualTo(
+                BotText.ExpenseView(
+                    amount = EXPENSE.amount,
+                    categoryName = draftCategoryName,
+                    expenseDate = EXPENSE.expenseDate,
+                    description = EXPENSE.description,
+                ),
+            )
+
+        verify(exactly = 1) { expenseService.updateExpenseFromDraftForUser(USER_ID, EXPENSE_ID, expenseDraft) }
         verify(exactly = 1) { categoryService.findCategoryForUser(CATEGORY_ID, USER_ID) }
         confirmVerified(expenseService, categoryService)
     }

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/service/ExpenseServiceTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/service/ExpenseServiceTest.kt
@@ -11,6 +11,7 @@ import me.kmozze.expensetracker.exception.BusinessException
 import me.kmozze.expensetracker.exception.SystemErrorCode
 import me.kmozze.expensetracker.exception.SystemException
 import me.kmozze.expensetracker.model.domain.ExpenseDraft
+import me.kmozze.expensetracker.model.domain.ExpenseDraftCategory
 import me.kmozze.expensetracker.model.domain.Money
 import me.kmozze.expensetracker.model.entity.Category
 import me.kmozze.expensetracker.model.entity.Expense
@@ -134,7 +135,7 @@ class ExpenseServiceTest {
             ExpenseDraft(
                 amount = Money.of(BigDecimal("650.00")),
                 description = "автобус",
-                categoryId = updatedCategoryId,
+                category = draftCategory(updatedCategoryId),
                 expenseDate = LocalDate.parse("2026-05-20"),
             )
         val updated =
@@ -299,7 +300,7 @@ class ExpenseServiceTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = "такси",
-                categoryId = categoryId,
+                category = draftCategory(categoryId),
                 expenseDate = expenseDate,
             )
         val expenseSlot = slot<Expense>()
@@ -342,7 +343,7 @@ class ExpenseServiceTest {
             ExpenseDraft(
                 amount = EXPENSE_AMOUNT,
                 description = "такси",
-                categoryId = categoryId,
+                category = draftCategory(categoryId),
                 expenseDate = LocalDate.parse("2026-05-24"),
             )
         val cause = DataAccessException("DB connection failed")
@@ -419,7 +420,7 @@ class ExpenseServiceTest {
                     ExpenseDraft(
                         amount = EXPENSE_AMOUNT,
                         description = "такси",
-                        categoryId = UUID.randomUUID(),
+                        category = draftCategory(UUID.randomUUID()),
                     ),
             )
         }
@@ -431,8 +432,14 @@ class ExpenseServiceTest {
         ExpenseDraft(
             amount = EXPENSE_AMOUNT,
             description = "такси",
-            categoryId = categoryId,
+            category = draftCategory(categoryId),
             expenseDate = LocalDate.parse("2026-05-24"),
+        )
+
+    private fun draftCategory(categoryId: UUID): ExpenseDraftCategory =
+        ExpenseDraftCategory(
+            categoryId = categoryId,
+            name = "Транспорт",
         )
 
     private companion object {


### PR DESCRIPTION
## Что сделано

- Убрано дублирование category/expense id из add/edit state: draft теперь хранит выбранную категорию как id + name.
- Добавлен ExpenseEditSession для edit-flow: expenseId и ExpenseDraft передаются одним объектом.
- Добавлены общие mapper-ы Expense/ExpenseDraft -> ExpenseView для карточек и draft-preview.
- Обновлены unit и integration tests под новый state/draft contract.

## Пройденные проверки

- Полный прогон тестов.
- Ручная проверка запуска бота.