### PR TITLE
test: cover edit review followups

### DIFF
--- a/src/test/kotlin/me/kmozze/expensetracker/integration/flow/EditExpenseFlowTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/integration/flow/EditExpenseFlowTest.kt
@@ -281,6 +281,80 @@ class EditExpenseFlowTest : AbstractFlowIntegrationTest() {
     }
 
     @Test
+    fun `cancel edit after multiple draft changes keeps saved expense unchanged`() {
+        val userId = 2014L
+        val chatId = 3014L
+
+        val createdExpense = createExpense(userId, chatId)
+        val initialExpense = createdExpense.first
+        val initialCategory = createdExpense.second
+
+        requestEdit(userId = userId, chatId = chatId, expenseId = initialExpense.id, callbackMessageId = CARD_MESSAGE_ID)
+
+        dialogueRouter.processUserInput(userId = userId, chatId = chatId, text = Buttons.EDIT_EXPENSE_AMOUNT)
+        dialogueRouter.processUserInput(userId = userId, chatId = chatId, text = "650")
+
+        val categorySelectionPrompt =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = Buttons.EDIT_EXPENSE_CATEGORY,
+            )
+        val categorySelection = categorySelectionPrompt.categorySelectionAction()
+        val newCategory =
+            categoryRepository
+                .findAllByUserId(userId)
+                .single { it.name == categorySelection.categoryNames.first { categoryName -> categoryName != initialCategory.name } }
+        assertThat(newCategory.id).isNotEqualTo(initialCategory.id)
+        dialogueRouter.processUserInput(userId = userId, chatId = chatId, text = newCategory.name)
+
+        dialogueRouter.processUserInput(userId = userId, chatId = chatId, text = Buttons.EDIT_EXPENSE_DATE)
+        dialogueRouter.processUserInput(userId = userId, chatId = chatId, text = Buttons.ENTER_DATE_MANUALLY)
+        dialogueRouter.processUserInput(userId = userId, chatId = chatId, text = MANUAL_DATE_TEXT)
+
+        dialogueRouter.processUserInput(userId = userId, chatId = chatId, text = Buttons.EDIT_EXPENSE_DESCRIPTION)
+        dialogueRouter.processUserInput(userId = userId, chatId = chatId, text = DESCRIPTION_UPDATED)
+
+        val unchangedBeforeCancel = expenseById(userId, initialExpense.id)
+        assertThat(unchangedBeforeCancel.amount).isEqualTo(EXPENSE_AMOUNT)
+        assertThat(unchangedBeforeCancel.categoryId).isEqualTo(initialCategory.id)
+        assertThat(unchangedBeforeCancel.expenseDate).isEqualTo(initialExpense.expenseDate)
+        assertThat(unchangedBeforeCancel.description).isEqualTo(EXPENSE_DESCRIPTION_UPDATED)
+
+        val editCanceled =
+            dialogueRouter.processUserInput(
+                userId = userId,
+                chatId = chatId,
+                text = Buttons.CANCEL,
+            )
+
+        editCanceled.assertMessage(
+            index = 0,
+            text = BotText.Done,
+            actions = listOf(BotAction.RemoveReplyKeyboard),
+        )
+        editCanceled.assertMessage(
+            index = 1,
+            text =
+                BotText.ExpenseView(
+                    amount = EXPENSE_AMOUNT,
+                    categoryName = initialCategory.name,
+                    expenseDate = initialExpense.expenseDate,
+                    description = EXPENSE_DESCRIPTION_UPDATED,
+                ),
+            actions = listOf(BotAction.ShowExpenseCardActions(initialExpense.id)),
+        )
+        editCanceled.assertNextState(UserState.Idle)
+
+        val savedAfterCancel = expenseById(userId, initialExpense.id)
+        assertThat(savedAfterCancel.amount).isEqualTo(EXPENSE_AMOUNT)
+        assertThat(savedAfterCancel.categoryId).isEqualTo(initialCategory.id)
+        assertThat(savedAfterCancel.expenseDate).isEqualTo(initialExpense.expenseDate)
+        assertThat(savedAfterCancel.description).isEqualTo(EXPENSE_DESCRIPTION_UPDATED)
+        assertThat(savedAfterCancel.id).isEqualTo(initialExpense.id)
+    }
+
+    @Test
     fun `edit unavailable expense from card shows unavailable message and resets state`() {
         val userId = 2012L
         val chatId = 3012L

--- a/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/expense/edit/AwaitingExpenseDateEditSelectionHandlerTest.kt
+++ b/src/test/kotlin/me/kmozze/expensetracker/unit/handler/statehandler/expense/edit/AwaitingExpenseDateEditSelectionHandlerTest.kt
@@ -29,6 +29,7 @@ import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.UUID
 
@@ -61,6 +62,31 @@ class AwaitingExpenseDateEditSelectionHandlerTest {
         val result = handle(UserCommand.SelectExpenseDate(ExpenseDateChoice.Yesterday))
 
         assertDraftDateSelectionResult(result, YESTERDAY)
+        confirmVerified(expenseService, categoryService)
+    }
+
+    @Test
+    fun `quick date selection uses Moscow date near midnight`() {
+        val moscowMidnightHandler =
+            AwaitingExpenseDateEditSelectionHandler(
+                expenseService = expenseService,
+                categoryService = categoryService,
+                clock = MOSCOW_MIDNIGHT_CLOCK,
+            )
+
+        val todayResult =
+            handle(
+                command = UserCommand.SelectExpenseDate(ExpenseDateChoice.Today),
+                handler = moscowMidnightHandler,
+            )
+        val yesterdayResult =
+            handle(
+                command = UserCommand.SelectExpenseDate(ExpenseDateChoice.Yesterday),
+                handler = moscowMidnightHandler,
+            )
+
+        assertDraftDateSelectionResult(todayResult, MOSCOW_TODAY)
+        assertDraftDateSelectionResult(yesterdayResult, MOSCOW_YESTERDAY)
         confirmVerified(expenseService, categoryService)
     }
 
@@ -135,17 +161,19 @@ class AwaitingExpenseDateEditSelectionHandlerTest {
             )
     }
 
-    private fun handle(command: UserCommand) =
-        handler.handle(
-            input =
-                makeUserInput(
-                    userId = USER_ID,
-                    chatId = CHAT_ID,
-                    text = textFor(command),
-                    command = command,
-                ),
-            currentState = AWAITING_EXPENSE_DATE_EDIT_SELECTION,
-        )
+    private fun handle(
+        command: UserCommand,
+        handler: AwaitingExpenseDateEditSelectionHandler = this.handler,
+    ) = handler.handle(
+        input =
+            makeUserInput(
+                userId = USER_ID,
+                chatId = CHAT_ID,
+                text = textFor(command),
+                command = command,
+            ),
+        currentState = AWAITING_EXPENSE_DATE_EDIT_SELECTION,
+    )
 
     private fun textFor(command: UserCommand): String? =
         when (command) {
@@ -160,8 +188,15 @@ class AwaitingExpenseDateEditSelectionHandlerTest {
         val EXPENSE_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
         val EXPENSE_AMOUNT: Money = Money.of(BigDecimal("500.00"))
         val CLOCK: Clock = Clock.fixed(Instant.parse("2026-05-24T12:00:00Z"), ZoneOffset.UTC)
+        val MOSCOW_MIDNIGHT_CLOCK: Clock =
+            Clock.fixed(
+                Instant.parse("2026-05-25T21:30:00Z"),
+                ZoneId.of("Europe/Moscow"),
+            )
         val TODAY: LocalDate = LocalDate.parse("2026-05-24")
         val YESTERDAY: LocalDate = LocalDate.parse("2026-05-23")
+        val MOSCOW_TODAY: LocalDate = LocalDate.parse("2026-05-26")
+        val MOSCOW_YESTERDAY: LocalDate = LocalDate.parse("2026-05-25")
         val EXPENSE: Expense =
             Expense(
                 id = EXPENSE_ID,


### PR DESCRIPTION
## Что сделано
- Добавлен integration test отмены накопленного draft редактирования расхода.
- Добавлен edit-flow boundary test для быстрых дат около московской полуночи.
- Закрыты follow-up замечания из review PR #63.

## Пройденные проверки
- Unit
- Полный прогон