### PR TITLE
ops: add deployable docker runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gradle
+build
+out
+bin
+
+.idea
+*.iws
+*.iml
+*.ipr
+
+.env
+.env.*
+
+.DS_Store
+Thumbs.db

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Local Docker app run settings. Do not put real production secrets here.
+BOT_TOKEN=
+POSTGRES_DB=expense_db
+DB_USER=user
+DB_PASSWORD=password

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ build/
 /out/
 /bin/
 
+### Local Environment ###
+.env
+.env.*
+!.env.example
+
 ### IntelliJ IDEA ###
 .idea/
 *.iws

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+
+WORKDIR /workspace
+
+COPY . .
+
+RUN ./gradlew jooqCodegen --no-daemon \
+    && ./gradlew bootJar --no-daemon \
+    && JAR_FILE="$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -n 1)" \
+    && cp "$JAR_FILE" app.jar
+
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+RUN addgroup -S expense && adduser -S expense -G expense
+
+COPY --from=builder /workspace/app.jar /app/app.jar
+
+RUN chown expense:expense /app/app.jar
+
+USER expense
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ src/test/kotlin/me/kmozze/expensetracker/
 
 Нужны JDK 21, Docker и Telegram bot token от BotFather.
 
-1. Поднять PostgreSQL:
+1. Поднять локальный PostgreSQL:
 
 ```bash
-docker compose up -d
+docker compose up -d postgres
 ```
 
 2. Экспортировать переменные окружения:
@@ -96,6 +96,65 @@ export BOT_TOKEN=<bot_token>
 
 Если этот же бот уже запущен в другом месте, long polling может конфликтовать. Для ручной проверки нужен один активный экземпляр.
 
+## Docker-запуск приложения
+
+Для запуска приложения в контейнере нужен реальный `BOT_TOKEN`. Локальные значения можно задать через shell или через `.env`; сам `.env` игнорируется git.
+
+Минимальный пример `.env`:
+
+```env
+BOT_TOKEN=<bot_token>
+POSTGRES_DB=expense_db
+DB_USER=user
+DB_PASSWORD=password
+```
+
+Запуск приложения вместе с PostgreSQL:
+
+```bash
+docker compose up --build
+```
+
+Если нужен только локальный PostgreSQL для запуска приложения через Gradle или для тестов:
+
+```bash
+docker compose up -d postgres
+```
+
+Health endpoint доступен на порту приложения:
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+
+Ожидаемый успешный ответ:
+
+```json
+{"status":"UP"}
+```
+
+Для остановки контейнеров:
+
+```bash
+docker compose down
+```
+
+Если этот же Telegram-бот уже запущен в другом месте, long polling может конфликтовать. Для smoke-check нужен один активный экземпляр с этим токеном.
+
+## Конфигурация запуска
+
+Приложение читает настройки из переменных окружения:
+
+| Переменная | Назначение | Локальное значение по умолчанию |
+| --- | --- | --- |
+| `BOT_TOKEN` | Telegram bot token; секрет, обязателен для запуска приложения | нет |
+| `DB_URL` | JDBC URL PostgreSQL без логина/пароля для обычного запуска через Gradle | нет |
+| `DB_USER` | Пользователь PostgreSQL | `user` |
+| `DB_PASSWORD` | Пароль PostgreSQL; секрет вне локального окружения | `password` |
+| `POSTGRES_DB` | Имя локальной БД в Docker Compose | `expense_db` |
+
+Docker Compose задает app-контейнеру внутренний `DB_URL` вида `jdbc:postgresql://postgres:5432/<POSTGRES_DB>`. Значения `user/password` предназначены только для локального Docker Compose. Для серверного окружения с уже развернутой БД нужен отдельный deploy-конфиг без локального `postgres` service.
+
 ## jOOQ
 
 jOOQ-код генерируется в:
@@ -125,7 +184,7 @@ build/generated-sources/jooq
 Перед полным прогоном тестов стоит поднять Docker/Postgres:
 
 ```bash
-docker compose up -d
+docker compose up -d postgres
 ./gradlew test
 ```
 
@@ -138,12 +197,18 @@ docker compose up -d
 Перед PR также стоит проверить, что приложение стартует:
 
 ```bash
-docker compose up -d
+docker compose up -d postgres
 ./gradlew jooqCodegen
 ./gradlew bootRun
 ```
 
 `jooqCodegen` нужен при первом локальном запуске, после очистки `build/` и после изменений схемы. Для этой проверки должны быть выставлены `DB_URL`, `DB_USER`, `DB_PASSWORD` и `BOT_TOKEN`. Успешный smoke-check - приложение стартовало без ошибок Spring context / Liquibase / Telegram long polling.
+
+Для проверки Docker runtime без запуска Telegram long polling можно собрать image:
+
+```bash
+docker compose build app
+```
 
 ## Текущие ограничения
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation("org.telegram:telegrambots-client:9.5.0")
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
     implementation("org.springframework.boot:spring-boot-starter-jooq")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,35 @@ services:
     container_name: expense-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: expense_db
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
+      POSTGRES_DB: ${POSTGRES_DB:-expense_db}
+      POSTGRES_USER: ${DB_USER:-user}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-password}
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build:
+      context: .
+    image: expense-tracker-bot:local
+    container_name: expense-tracker-bot
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      - DB_URL=jdbc:postgresql://postgres:5432/${POSTGRES_DB:-expense_db}
+      - DB_USER=${DB_USER:-user}
+      - DB_PASSWORD=${DB_PASSWORD:-password}
+      - BOT_TOKEN
+    ports:
+      - "8080:8080"
 
 volumes:
   postgres_data:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,3 +17,9 @@ spring:
 
 bot:
   token: ${BOT_TOKEN}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health


### PR DESCRIPTION
## Что сделано

- Добавлен Docker runtime для Spring Boot приложения.
- Расширен локальный Docker Compose: по умолчанию поднимается app + PostgreSQL, а только БД можно поднять командой `docker compose up -d postgres`.
- Добавлен минимальный Actuator health endpoint.
- Задокументирован env contract и Docker-запуск без коммита секретов.

Закрывает tech debt: уточнить `docker-compose.yml` из `docs/TECH_DEBT.md`.

## Пройденные проверки

- Unit и integration tests
- Полный прогон
- Ручная проверка Docker Compose config и Docker image build