### PR TITLE
ci: publish docker image manually

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,83 @@
+name: Publish Docker Image
+run-name: "${{ github.workflow }} - ${{ github.event_name == 'pull_request' && format('PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title) || github.ref_name }}"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/publish-image.yml"
+      - ".dockerignore"
+      - "Dockerfile"
+      - "build.gradle.kts"
+      - "settings.gradle.kts"
+      - "gradle/**"
+      - "gradlew"
+      - "src/**"
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  IMAGE_NAME: ghcr.io/kmozze/expense-tracker-bot
+
+jobs:
+  build:
+    name: Build image
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: ${{ env.IMAGE_NAME }}:pr-${{ github.event.pull_request.number }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/kmozze/expense-tracker-bot
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  publish:
+    name: Publish image
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: publish-image-manual
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:manual
+          labels: |
+            org.opencontainers.image.source=https://github.com/kmozze/expense-tracker-bot
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -155,6 +155,37 @@ docker compose down
 
 Docker Compose задает app-контейнеру внутренний `DB_URL` вида `jdbc:postgresql://postgres:5432/<POSTGRES_DB>`. Значения `user/password` предназначены только для локального Docker Compose. Для серверного окружения с уже развернутой БД нужен отдельный deploy-конфиг без локального `postgres` service.
 
+## Docker image
+
+Опубликованный image живет в GHCR:
+
+```text
+ghcr.io/kmozze/expense-tracker-bot
+```
+
+Публикация выполняется вручную через GitHub Actions workflow `Publish Docker Image`. Workflow публикует два тега:
+
+- `sha-<commit_sha>` - воспроизводимый тег конкретного commit;
+- `manual` - последний вручную опубликованный image.
+
+`latest` пока не используется: у проекта еще нет release/deploy-семантики для этого тега.
+
+Запуск опубликованного image предполагает уже доступную PostgreSQL БД:
+
+```bash
+export COMMIT_SHA=replace_with_commit_sha
+
+docker run --rm \
+  -e BOT_TOKEN="$BOT_TOKEN" \
+  -e DB_URL="$DB_URL" \
+  -e DB_USER="$DB_USER" \
+  -e DB_PASSWORD="$DB_PASSWORD" \
+  -p 8080:8080 \
+  ghcr.io/kmozze/expense-tracker-bot:sha-${COMMIT_SHA}
+```
+
+Реальный deploy на сервер, restart policy и отдельный compose для внешней БД будут описаны отдельным шагом.
+
 ## jOOQ
 
 jOOQ-код генерируется в:


### PR DESCRIPTION
## Что сделано

- Добавлен ручной workflow публикации Docker image в GHCR.
- PR workflow делает dry-run сборку image без push и без `packages: write`.
- Manual publish публикует `ghcr.io/kmozze/expense-tracker-bot` с тегами `sha-<commit_sha>` и `manual`.
- README дополнен контрактом тегов и примером запуска опубликованного image с внешней БД.

Stacked on PR #68.

## Пройденные проверки

- Unit и integration tests
- Полный прогон
- Ручная проверка Docker image build